### PR TITLE
fixes entry insert when index is reverted at the same time

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
+- BooleanIndex was wrong when index inversion occured
+  when an existing content was reindexed with an opposite value.
+  Fixes LP #1236354.
 
 3.0 (2013-02-24)
 ----------------

--- a/src/Products/PluginIndexes/BooleanIndex/tests.py
+++ b/src/Products/PluginIndexes/BooleanIndex/tests.py
@@ -233,4 +233,5 @@ class TestBooleanIndex(unittest.TestCase):
         self.assertFalse(index._index_value)
 
         res = index._apply_index({'truth': True})[0]
+        self.assertEqual(list(index._index), [2])
         self.assertEqual(list(res), [1, 3, 4])


### PR DESCRIPTION
Hi, this commit fixes a critical problem i encountered. The value inserted at the moment when the index is inverted was wrong (the value was set as false instead of true at the moment index value was inverted from false to true)

do you have an opinion about this ?

the problem is that i am not 100% sure that this commit is good. Obviously it won't introduce a regression (this looks more robust) but i coul'nt write a test to prove the problem i encountered can be reproduced.
