### PR TITLE
[BACKPORT] Avoid potentially expensive `len()` call in value index estimation

### DIFF
--- a/src/Products/ZCatalog/plan.py
+++ b/src/Products/ZCatalog/plan.py
@@ -201,7 +201,15 @@ class CatalogPlan(object):
         for name, index in indexes.items():
             if IUniqueValueIndex.providedBy(index):
                 values = index.uniqueValues()
-                if values and len(list(values)) < MAX_DISTINCT_VALUES:
+                i = 0
+                for value in values:
+                    # the total number of unique values might be large and
+                    # expensive to load, so we only check if we can get
+                    # more than MAX_DISTINCT_VALUES
+                    if i >= MAX_DISTINCT_VALUES:
+                        break
+                    i += 1
+                if i > 0 and i < MAX_DISTINCT_VALUES:
                     # Only consider indexes which actually return a number
                     # greater than zero
                     value_indexes.add(name)


### PR DESCRIPTION
backport @hannosch fix for ZCatalog plan on branch 2.13

https://github.com/zopefoundation/Products.ZCatalog/commit/3770bc998a2656ecdcfc494d5996e6a89fbc2365

Avoid potentially expensive `len()` call in value index estimation.

Instead iterate over unique values and break if we can get more than
`MAX_DISTINCT_VALUES` values. Also correctly identify empty indexes like the
DateRangeIndex, which only returns values when the name argument is provided
to the uniqueValues method with either the `since` or `until` field.
