### PR TITLE
fix for issue #6, Run ZODB cache garbage collection when returning large result sets

### DIFF
--- a/src/Products/ZCatalog/Catalog.py
+++ b/src/Products/ZCatalog/Catalog.py
@@ -415,10 +415,16 @@ class Catalog(Persistent, Acquisition.Implicit, ExtensionClass.Base):
             record.append(attr)
         return tuple(record)
 
+    def _maintain_zodb_cache(self):
+        parent = aq_parent(self)
+        if hasattr(aq_base(parent), 'maintain_zodb_cache'):
+            parent.maintain_zodb_cache()
+
     def instantiate(self, record, score_data=None):
         """ internal method: create and initialise search result object.
         record should be a tuple of (document RID, metadata columns tuple),
         score_data can be a tuple of (scode, normalized score) or be omitted"""
+        self._maintain_zodb_cache()
         key, data = record
         klass = self._v_result_class
         if score_data:

--- a/src/Products/ZCatalog/tests/test_catalog.py
+++ b/src/Products/ZCatalog/tests/test_catalog.py
@@ -919,8 +919,13 @@ class TestCatalogReturnAll(unittest.TestCase):
         for x in range(0, 10):
             catalog.catalogObject(dummy(x), repr(x))
         self.assertEqual(len(catalog), 10)
-        length = len(catalog({}))
-        self.assertEqual(length, 10)
+        all_data = catalog({})
+        self.assertEqual(len(all_data), 10)
+        for rec in all_data:
+            self.assertEqual(rec.aq_parent, catalog)
+            self.assertNotEqual(rec.data_record_id_, None)
+            self.assertEqual(rec.data_record_score_, None)
+            self.assertEqual(rec.data_record_normalized_score_, None)
 
 
 class TestCatalogSearchArgumentsMap(unittest.TestCase):

--- a/src/Products/ZCatalog/tests/test_zodb.py
+++ b/src/Products/ZCatalog/tests/test_zodb.py
@@ -1,0 +1,120 @@
+##############################################################################
+#
+# Copyright (c) 2002 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+""" Unittests for ZCatalog interaction with ZODB persistency
+"""
+
+import ExtensionClass
+from OFS.Folder import Folder
+from Products.PluginIndexes.FieldIndex.FieldIndex import FieldIndex
+from Products.ZCatalog.ZCatalog import ZCatalog
+import random
+from Testing.makerequest import makerequest
+import sys
+import transaction
+import unittest
+import Zope2
+
+
+class zdummy(ExtensionClass.Base):
+    meta_type = 'dummy'
+
+    def __init__(self, num):
+        self.id = 'dummy_%d' % (num,)
+        self.title = 'Dummy %d' % (num,)
+
+
+class TestPersistentZCatalog(unittest.TestCase):
+
+    def setUp(self):
+        self.app = makerequest(Zope2.app())
+        self.app._setObject('Catalog', ZCatalog('Catalog'))
+        self.app.Catalog.addIndex('meta_type', FieldIndex('meta_type'))
+        self.app.Catalog.addColumn('id')
+        self.app.Catalog.addColumn('title')
+        self.app._setObject('Database', Folder('Database'))
+        # newly added objects have ._p_jar == None, initialize it
+        transaction.savepoint()
+
+    def tearDown(self):
+        for obj_id in ('Catalog', 'Database'):
+            self.app._delObject(obj_id, suppress_events=True)
+
+    def _make_dummy(self):
+        num = random.randint(0, sys.maxint)
+        return zdummy(num)
+
+    def _make_persistent_folder(self, obj_id):
+        self.app.Database._setObject(obj_id, Folder(obj_id))
+        result = self.app.Database[obj_id]
+        result.title = 'Folder %s' % (obj_id,)
+        return result
+
+    def _get_zodb_info(self, obj):
+        conn = obj._p_jar
+        cache_size_limit = conn.db().getCacheSize()
+        return conn, cache_size_limit
+
+    def _actual_cache_size(self, obj):
+        return obj._p_jar._cache.cache_non_ghost_count
+
+    NUM_RESULTS = 1500
+    TIMES_MORE = 10
+
+    def _fill_catalog(self, catalog, num_objects):
+        # catalog num_objects of "interesting" documents
+        # and intersperse them with (num_objects * TIMES_MORE) of dummy objects,
+        # making sure that "interesting" objects do not share
+        # the same metadata bucket (as it happens in typical use)
+        def catalog_dummies(num_dummies):
+            for j in range(num_dummies):
+                obj = self._make_dummy()
+                catalog.catalog_object(obj, uid=obj.id)
+        for i in range(num_objects):
+            # catalog average of TIMES_MORE / 2 dummy objects
+            catalog_dummies(random.randint(1, self.TIMES_MORE))
+            # catalog normal object
+            obj_id = 'folder_%i' % (i,)
+            catalog.catalog_object(self._make_persistent_folder(obj_id))
+            # catalog another TIMES_MORE / 2 dummy objects
+            catalog_dummies(random.randint(1, self.TIMES_MORE))
+        # attach new persistent objects to ZODB connection
+        transaction.savepoint()
+
+    def _test_catalog_search(self, threshold=None):
+        catalog = self.app.Catalog
+        self._fill_catalog(catalog, self.NUM_RESULTS)
+        conn, ignore = self._get_zodb_info(catalog)
+        conn.cacheGC()
+        # run large query and read its results
+        catalog.threshold = threshold
+        aggregate = 0
+        for record in catalog(meta_type='Folder'):
+            aggregate += len(record.title)
+        return catalog
+
+    def test_unmaintained_search(self):
+        # run large query without cache maintenance
+        catalog = self._test_catalog_search(threshold=None)
+        ignore, cache_size_limit = self._get_zodb_info(catalog)
+        # ZODB connection cache grows out of size limit and eats memory
+        actual_size = self._actual_cache_size(catalog)
+        self.assertTrue(actual_size > cache_size_limit * 2)
+
+    def test_maintained_search(self):
+        # run big query with cache maintenance
+        threshold = 128
+        catalog = self._test_catalog_search(threshold=threshold)
+        ignore, cache_size_limit = self._get_zodb_info(catalog)
+        # ZODB connection cache stays within its size limit
+        actual_size = self._actual_cache_size(catalog)
+        self.assertTrue(actual_size <= cache_size_limit + threshold)


### PR DESCRIPTION
Proposed is branch that calls `Connection.cacheGC()` after each `ZCatalog.threshold` reads from a query result set within a single transaction.

That should prevent ZODB cache from being overfilled with metadata IOBuckets when reading result records from a long query in sufficiently large ZCatalog.

More details are given in the [issue itself](https://github.com/zopefoundation/Products.ZCatalog/issues/6), examples are provided in the [unit test `test_zodb.py`](https://github.com/eprigorodov/Products.ZCatalog/blob/issue6-cacheGC-on-search/src/Products/ZCatalog/tests/test_zodb.py).


