### PR TITLE
Caching support for UnIndex

### DIFF
--- a/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
+++ b/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
@@ -35,17 +35,12 @@ from zope.interface import implements
 
 from Products.PluginIndexes.common import safe_callable
 from Products.PluginIndexes.common.UnIndex import UnIndex
+from Products.PluginIndexes.common.UnIndex import RequestCache
 from Products.PluginIndexes.common.util import parseIndexRequest
 from Products.PluginIndexes.interfaces import IDateRangeIndex
 
 _dtmldir = os.path.join(package_home(globals()), 'dtml')
 MAX32 = int(2 ** 31 - 1)
-
-
-class RequestCache(dict):
-
-    def __str__(self):
-        return "<RequestCache %s items>" % len(self)
 
 
 class DateRangeIndex(UnIndex):
@@ -231,13 +226,6 @@ class DateRangeIndex(UnIndex):
                         yield (key, 1)
                     else:
                         yield (key, len(value))
-
-    def _cache_key(self, catalog):
-        cid = catalog.getId()
-        counter = getattr(aq_base(catalog), 'getCounter', None)
-        if counter is not None:
-            return '%s_%s' % (cid, counter())
-        return cid
 
     def _apply_index(self, request, resultset=None):
         """Apply the index to query parameters given in 'request', which

--- a/src/Products/PluginIndexes/common/UnIndex.py
+++ b/src/Products/PluginIndexes/common/UnIndex.py
@@ -353,7 +353,7 @@ class UnIndex(SimpleItem):
             return '%s_%s' % (cid, counter())
         return cid
 
-    def _record_cache_key(self,record):
+    def _record_cache_key(self, record, resultset=None):
         params = []
 
         operator = record.get('operator', self.useOperator)

--- a/src/Products/PluginIndexes/common/UnIndex.py
+++ b/src/Products/PluginIndexes/common/UnIndex.py
@@ -15,6 +15,11 @@ from cgi import escape
 from logging import getLogger
 import sys
 
+from Acquisition import aq_base
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from Acquisition import aq_get
+
 from BTrees.IIBTree import difference
 from BTrees.IIBTree import intersection
 from BTrees.IIBTree import IITreeSet
@@ -36,6 +41,9 @@ from Products.PluginIndexes.interfaces import IUniqueValueIndex
 _marker = []
 LOG = getLogger('Zope.UnIndex')
 
+class RequestCache(dict):
+    def __str__(self):
+        return "<RequestCache %s items>" % len(self)
 
 class UnIndex(SimpleItem):
 
@@ -304,6 +312,55 @@ class UnIndex(SimpleItem):
     def _convert(self, value, default=None):
         return value
 
+    def _catalog_cache_key(self, catalog):
+        cid = catalog.getId()
+        counter = getattr(aq_base(catalog), 'getCounter', None)
+        if counter is not None:
+            return '%s_%s' % (cid, counter())
+        return cid
+
+    def _record_cache_key(self,record):
+        params = []
+
+        operator = record.get('operator', self.useOperator)
+        if operator != 'or':
+            # operator is not supported
+            return None
+
+        not_parm = record.get('not', None)
+        if not_parm:
+
+            if isinstance(not_parm,list):
+                not_parm = tuple(not_parm)
+            elif not isinstance(not_parm,tuple):
+                not_parm = (not_parm,)
+
+            not_parm = list(kw)
+            not_parm.sort()
+            not_parm = tuple(not_parm )
+            params.append(('not', not_parm))
+        
+        range_parm = record.get('range', None)
+        if range_parm:
+            params.append(('range_parm', range_parm))
+
+        usage_parm = record.get('usage', None)
+        if usage_parm:
+            params.append(('usage_parm', usage_parm))
+
+        kw = record.keys
+        if isinstance(kw,list):
+            kw = tuple(kw)
+        elif not isinstance(kw,tuple):
+            kw = (kw,)
+             
+        kl = list(kw)
+        kl.extend(params)
+        kl.sort()
+        key = tuple(kl)
+
+        return (self.id,key)
+
     def _apply_index(self, request, resultset=None):
         """Apply the index to query parameters given in the request arg.
 
@@ -349,6 +406,28 @@ class UnIndex(SimpleItem):
 
         # not / exclude parameter
         not_parm = record.get('not', None)
+        cachekey = None
+        REQUEST = aq_get(self, 'REQUEST', None)
+        if REQUEST is not None:
+            catalog = aq_parent(aq_parent(aq_inner(self)))
+            if catalog is not None:
+                key = self._catalog_cache_key(catalog)
+                cache = REQUEST.get(key, None)
+                cachekey = self._record_cache_key(record)
+                if cache is None:
+                    cache = REQUEST[key] = RequestCache()
+                elif cachekey is not None:
+                    cached = cache.get(cachekey, None)
+                    if cached is not None:
+                        LOG.debug('%s catalog: %s index: %s cachekey: %s -> hit' % (self.__class__.__name__,key, str(self.id), str(cachekey)))
+                        if not_parm:
+                            not_parm = map(self._convert, not_parm)
+                            exclude = self._apply_not(not_parm, resultset)
+                            r = difference(cached, exclude)
+                            return r, (self.id,)
+
+                        return cached, (self.id,)
+
         if not record.keys and not_parm:
             # convert into indexed format
             not_parm = map(self._convert, not_parm)
@@ -397,6 +476,10 @@ class UnIndex(SimpleItem):
                 result = setlist[0]
                 if isinstance(result, int):
                     result = IISet((result,))
+                
+                if cachekey is not None:
+                    cache[cachekey] = result               
+
                 if not_parm:
                     exclude = self._apply_not(not_parm, resultset)
                     result = difference(result, exclude)
@@ -409,6 +492,9 @@ class UnIndex(SimpleItem):
                         s = IISet((s,))
                     tmp.append(s)
                 r = multiunion(tmp)
+
+                if cachekey is not None:
+                    cache[cachekey] = r
             else:
                 # For intersection, sort with smallest data set first
                 tmp = []
@@ -424,7 +510,7 @@ class UnIndex(SimpleItem):
                 for s in setlist:
                     # the result is bound by the resultset
                     r = intersection(r, s)
-
+                    
         else:  # not a range search
             # Filter duplicates
             setlist = []
@@ -448,6 +534,10 @@ class UnIndex(SimpleItem):
                 result = setlist[0]
                 if isinstance(result, int):
                     result = IISet((result,))
+
+                if cachekey is not None:
+                    cache[cachekey] = result
+
                 if not_parm:
                     exclude = self._apply_not(not_parm, resultset)
                     result = difference(result, exclude)
@@ -457,13 +547,15 @@ class UnIndex(SimpleItem):
                 # If we already get a small result set passed in, intersecting
                 # the various indexes with it and doing the union later is
                 # faster than creating a multiunion first.
-                if resultset is not None and len(resultset) < 200:
+                if cachekey is None and resultset is not None and len(resultset) < 200:
                     smalllist = []
                     for s in setlist:
                         smalllist.append(intersection(resultset, s))
                     r = multiunion(smalllist)
                 else:
                     r = multiunion(setlist)
+                    if cachekey is not None:
+                        cache[cachekey] = r                    
             else:
                 # For intersection, sort with smallest data set first
                 if len(setlist) > 2:

--- a/src/Products/PluginIndexes/common/UnIndex.py
+++ b/src/Products/PluginIndexes/common/UnIndex.py
@@ -510,6 +510,9 @@ class UnIndex(SimpleItem):
                 for s in setlist:
                     # the result is bound by the resultset
                     r = intersection(r, s)
+                    # If intersection, we can't possibly get a smaller result
+                    if not r:
+                        break
                     
         else:  # not a range search
             # Filter duplicates
@@ -563,6 +566,9 @@ class UnIndex(SimpleItem):
                 r = resultset
                 for s in setlist:
                     r = intersection(r, s)
+                    # If intersection, we can't possibly get a smaller result
+                    if not r:
+                        break
 
         if isinstance(r, int):
             r = IISet((r, ))


### PR DESCRIPTION
Hi,

I have adopted the caching mechanism of DateRangeIndex in order to improve the performance of catalog queries calling repetitively indexes inherited from UnIndex (e.g. FieldIndex, KeywordIndex etc.). The performance enhancement becomes especially noticeable on big sites. For example, in plone are the indexes review_state, portal_type, allowedRolesAndUsers etc. within a request affected. 

Kind regards
Andreas