### PR TITLE
Request caching support for UnIndex 

### DIFF
--- a/src/Products/PluginIndexes/DateIndex/DateIndex.py
+++ b/src/Products/PluginIndexes/DateIndex/DateIndex.py
@@ -18,10 +18,6 @@ from datetime import tzinfo, timedelta
 
 from App.special_dtml import DTMLFile
 from BTrees.IIBTree import IIBTree
-from BTrees.IIBTree import IISet
-from BTrees.IIBTree import union
-from BTrees.IIBTree import intersection
-from BTrees.IIBTree import multiunion
 from BTrees.IOBTree import IOBTree
 from BTrees.Length import Length
 from DateTime.DateTime import DateTime
@@ -31,7 +27,6 @@ from zope.interface import implements
 
 from Products.PluginIndexes.common import safe_callable
 from Products.PluginIndexes.common.UnIndex import UnIndex
-from Products.PluginIndexes.common.util import parseIndexRequest
 from Products.PluginIndexes.interfaces import IDateIndex
 
 LOG = getLogger('DateIndex')
@@ -100,7 +95,7 @@ class DateIndex(UnIndex, PropertyManager):
     manage_main._setName('manage_main')
     manage_options = ({'label': 'Settings', 'action': 'manage_main'},
                       {'label': 'Browse', 'action': 'manage_browse'},
-                     ) + PropertyManager.manage_options
+                      ) + PropertyManager.manage_options
 
     def clear(self):
         """ Complete reset """
@@ -193,5 +188,5 @@ manage_addDateIndexForm = DTMLFile('dtml/addDateIndex', globals())
 
 def manage_addDateIndex(self, id, REQUEST=None, RESPONSE=None, URL3=None):
     """Add a Date index"""
-    return self.manage_addIndex(id, 'DateIndex', extra=None, \
-                    REQUEST=REQUEST, RESPONSE=RESPONSE, URL1=URL3)
+    return self.manage_addIndex(id, 'DateIndex', extra=None,
+                                REQUEST=REQUEST, RESPONSE=RESPONSE, URL1=URL3)

--- a/src/Products/PluginIndexes/DateIndex/tests.py
+++ b/src/Products/PluginIndexes/DateIndex/tests.py
@@ -33,13 +33,14 @@ class Dummy:
 # excerpted from the Python module docs
 ###############################################################################
 
+
 def _getEastern():
-    from datetime import date
     from datetime import datetime
     from datetime import timedelta
     from datetime import tzinfo
     ZERO = timedelta(0)
     HOUR = timedelta(hours=1)
+
     def first_sunday_on_or_after(dt):
         days_to_go = 6 - dt.weekday()
         if days_to_go:
@@ -112,18 +113,18 @@ class DI_Tests(unittest.TestCase):
         from datetime import date
         from datetime import datetime
         return [
-            (0, Dummy('a', None)),                            # None
-            (1, Dummy('b', DateTime(0))),                     # 1055335680
-            (2, Dummy('c', DateTime('2002-05-08 15:16:17'))), # 1072667236
-            (3, Dummy('d', DateTime('2032-05-08 15:16:17'))), # 1088737636
-            (4, Dummy('e', DateTime('2062-05-08 15:16:17'))), # 1018883325
-            (5, Dummy('e', DateTime('2062-05-08 15:16:17'))), # 1018883325
-            (6, Dummy('f', 1072742620.0)),                    # 1073545923
-            (7, Dummy('f', 1072742900)),                      # 1073545928
-            (8, Dummy('g', date(2034,2,5))),                  # 1073599200
-            (9, Dummy('h', datetime(2034,2,5,15,20,5))),      # (varies)
-            (10, Dummy('i', datetime(2034,2,5,10,17,5,
-                                     tzinfo=_getEastern()))), # 1073600117
+            (0, Dummy('a', None)),                             # None
+            (1, Dummy('b', DateTime(0))),                      # 1055335680
+            (2, Dummy('c', DateTime('2002-05-08 15:16:17'))),  # 1072667236
+            (3, Dummy('d', DateTime('2032-05-08 15:16:17'))),  # 1088737636
+            (4, Dummy('e', DateTime('2062-05-08 15:16:17'))),  # 1018883325
+            (5, Dummy('e', DateTime('2062-05-08 15:16:17'))),  # 1018883325
+            (6, Dummy('f', 1072742620.0)),                     # 1073545923
+            (7, Dummy('f', 1072742900)),                       # 1073545928
+            (8, Dummy('g', date(2034, 2, 5))),                 # 1073599200
+            (9, Dummy('h', datetime(2034, 2, 5, 15, 20, 5))),  # (varies)
+            (10, Dummy('i', datetime(2034, 2, 5, 10, 17, 5,
+                                     tzinfo=_getEastern()))),  # 1073600117
         ]
 
     def _populateIndex(self, index):
@@ -136,7 +137,7 @@ class DI_Tests(unittest.TestCase):
             result = result.keys()
         self.assertEqual(used, ('date',))
         self.assertEqual(len(result), len(expectedValues),
-            '%s | %s' % (result, expectedValues))
+                         '%s | %s' % (result, expectedValues))
         for k, v in expectedValues:
             self.assertTrue(k in result)
 
@@ -150,7 +151,7 @@ class DI_Tests(unittest.TestCase):
         elif type(dt) is date:
             yr, mo, dy, hr, mn = dt.timetuple()[:5]
         elif type(dt) is datetime:
-            if dt.tzinfo is None: # default behavior of index
+            if dt.tzinfo is None:  # default behavior of index
                 dt = dt.replace(tzinfo=Local)
             yr, mo, dy, hr, mn = dt.utctimetuple()[:5]
         else:
@@ -179,7 +180,7 @@ class DI_Tests(unittest.TestCase):
         self.assertTrue(index.getEntryForObject(1234) is None)
         marker = []
         self.assertTrue(index.getEntryForObject(1234, marker) is marker)
-        index.unindex_object(1234) # shouldn't throw
+        index.unindex_object(1234)  # shouldn't throw
 
         self.assertTrue(index.hasUniqueValuesFor('date'))
         self.assertFalse(index.hasUniqueValuesFor('foo'))
@@ -198,8 +199,9 @@ class DI_Tests(unittest.TestCase):
                                    'range': 'max'}},
                          [])
         self._checkApply(index,
-                         {'date': {'query':(DateTime('2002-05-08 15:16:17'),
-                                            DateTime('2062-05-08 15:16:17')),
+                         {'date': {'query':
+                                   (DateTime('2002-05-08 15:16:17'),
+                                    DateTime('2062-05-08 15:16:17')),
                                    'range': 'min:max'}},
                          [])
 
@@ -209,19 +211,19 @@ class DI_Tests(unittest.TestCase):
         self._populateIndex(index)
         values = self._getValues()
 
-        self.assertEqual(len(index), len(values) - 2) # One dupe, one empty
+        self.assertEqual(len(index), len(values) - 2)  # One dupe, one empty
         self.assertEqual(len(index.referencedObjects()), len(values) - 1)
             # One empty
 
         self.assertTrue(index.getEntryForObject(1234) is None)
         marker = []
         self.assertTrue(index.getEntryForObject(1234, marker) is marker)
-        index.unindex_object(1234) # shouldn't throw
+        index.unindex_object(1234)  # shouldn't throw
 
         for k, v in values:
             if v.date():
                 self.assertEqual(index.getEntryForObject(k),
-                    self._convert(v.date()))
+                                 self._convert(v.date()))
 
         self.assertEqual(
             len(list(index.uniqueValues('date'))), len(values) - 2)
@@ -238,15 +240,15 @@ class DI_Tests(unittest.TestCase):
                                    'range': 'max'}},
                          values[1:4] + values[6:8])
         self._checkApply(index,
-                         {'date': {'query':(DateTime('2002-05-08 15:16:17'),
-                                            DateTime('2062-05-08 15:16:17')),
+                         {'date': {'query':
+                                   (DateTime('2002-05-08 15:16:17'),
+                                    DateTime('2062-05-08 15:16:17')),
                                    'range': 'min:max'}},
-                         values[2:] )
+                         values[2:])
         self._checkApply(index,
                          {'date': 1072742620.0}, [values[6]])
         self._checkApply(index,
                          {'date': 1072742900}, [values[7]])
-
 
     def test_not(self):
         from DateTime import DateTime
@@ -256,8 +258,10 @@ class DI_Tests(unittest.TestCase):
         # all but the None value
         self._checkApply(index, {'date': {'not': 123}}, values[1:])
         self._checkApply(index, {'date': {'not': DateTime(0)}}, values[2:])
-        self._checkApply(index, {'date': {'not':
-            [DateTime(0), DateTime('2002-05-08 15:16:17')]}}, values[3:])
+        self._checkApply(index, {'date':
+                                 {'not': [DateTime(0),
+                                          DateTime('2002-05-08 15:16:17')]}},
+                         values[3:])
 
     def test_naive_convert_to_utc(self):
         index = self._makeOne()
@@ -300,7 +304,7 @@ class DI_Tests(unittest.TestCase):
 
         # unknown id
         index.unindex_object(1234)
-        self.assertEqual(index.getCounter(), 2)    
+        self.assertEqual(index.getCounter(), 2)
 
         index.clear()
         self.assertEqual(index.getCounter(), 0)

--- a/src/Products/PluginIndexes/DateIndex/tests.py
+++ b/src/Products/PluginIndexes/DateIndex/tests.py
@@ -319,6 +319,15 @@ class DI_Tests(unittest.TestCase):
 
 class DI_Cache_Tests(DI_Tests):
 
+    def _dummy_test(self):
+        # dummy function
+        pass
+
+    # following methods do not require a cache test
+    test_interfaces = _dummy_test
+    test_naive_convert_to_utc = _dummy_test
+    test_getCounter = _dummy_test
+
     def _makeOne(self, id='date'):
 
         index = super(DI_Cache_Tests, self).\

--- a/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
+++ b/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
@@ -229,7 +229,6 @@ class DateRangeIndex(UnIndex):
                         yield (key, len(value))
 
     def _record_cache_key(self, record, resultset=None):
-        iid = self.id
         term = self._convertDateTime(record.keys[0])
 
         # why flatten to 10 minutes? 'term' is already flattened
@@ -237,11 +236,16 @@ class DateRangeIndex(UnIndex):
         # tid = isinstance(term, int) and term / 10 or 'None'
         tid = str(term)
 
+        # unique index identifier
+        iid = '_%s_%s_%s' % (self.__class__.__name__,
+                             self.id, self.getCounter())
+        # record identifier
         if resultset is None:
-            cachekey = '_daterangeindex_%s_%s' % (iid, tid)
+            rid = '_%s' % (tid, )
         else:
-            cachekey = '_daterangeindex_inverse_%s_%s' % (iid, tid)
-        return cachekey
+            rid = '_inverse_%s' % (tid, )
+
+        return (iid, rid)
 
     def _apply_index(self, request, resultset=None):
         """Apply the index to query parameters given in 'request', which

--- a/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
+++ b/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
@@ -18,10 +18,6 @@ from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import manage_zcatalog_indexes
 from AccessControl.Permissions import view
 from AccessControl.SecurityInfo import ClassSecurityInfo
-from Acquisition import aq_base
-from Acquisition import aq_get
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from App.Common import package_home
 from App.special_dtml import DTMLFile
 from BTrees.IIBTree import IITreeSet
@@ -40,12 +36,6 @@ from Products.PluginIndexes.interfaces import IDateRangeIndex
 
 _dtmldir = os.path.join(package_home(globals()), 'dtml')
 MAX32 = int(2 ** 31 - 1)
-
-
-class RequestCache(dict):
-
-    def __str__(self):
-        return "<RequestCache %s items>" % len(self)
 
 
 class DateRangeIndex(UnIndex):
@@ -238,12 +228,20 @@ class DateRangeIndex(UnIndex):
                     else:
                         yield (key, len(value))
 
-    def _cache_key(self, catalog):
-        cid = catalog.getId()
-        counter = getattr(aq_base(catalog), 'getCounter', None)
-        if counter is not None:
-            return '%s_%s' % (cid, counter())
-        return cid
+    def _record_cache_key(self, record, resultset=None):
+        iid = self.id
+        term = self._convertDateTime(record.keys[0])
+
+        # why flatten to 10 minutes? 'term' is already flattened
+        # to minutes by _convertDateTime.
+        # tid = isinstance(term, int) and term / 10 or 'None'
+        tid = str(term)
+
+        if resultset is None:
+            cachekey = '_daterangeindex_%s_%s' % (iid, tid)
+        else:
+            cachekey = '_daterangeindex_inverse_%s_%s' % (iid, tid)
+        return cachekey
 
     def _apply_index(self, request, resultset=None):
         """Apply the index to query parameters given in 'request', which
@@ -257,35 +255,23 @@ class DateRangeIndex(UnIndex):
         second object is a tuple containing the names of all data fields
         used.
         """
-        iid = self.id
-        record = parseIndexRequest(request, iid, self.query_options)
+        record = parseIndexRequest(request, self.id, self.query_options)
         if record.keys is None:
             return None
 
-        term = self._convertDateTime(record.keys[0])
-        REQUEST = aq_get(self, 'REQUEST', None)
-        if REQUEST is not None:
-            catalog = aq_parent(aq_parent(aq_inner(self)))
-            if catalog is not None:
-                key = self._cache_key(catalog)
-                cache = REQUEST.get(key, None)
-                tid = isinstance(term, int) and term / 10 or 'None'
+        cache = self.getRequestCache()
+        if cache is not None:
+            cachekey = self._record_cache_key(record, resultset)
+            cached = cache.get(cachekey, None)
+            if cached is not None:
                 if resultset is None:
-                    cachekey = '_daterangeindex_%s_%s' % (iid, tid)
+                    return (cached,
+                            (self._since_field, self._until_field))
                 else:
-                    cachekey = '_daterangeindex_inverse_%s_%s' % (iid, tid)
-                if cache is None:
-                    cache = REQUEST[key] = RequestCache()
-                else:
-                    cached = cache.get(cachekey, None)
-                    if cached is not None:
-                        if resultset is None:
-                            return (cached,
-                                    (self._since_field, self._until_field))
-                        else:
-                            return (difference(resultset, cached),
-                                    (self._since_field, self._until_field))
+                    return (difference(resultset, cached),
+                            (self._since_field, self._until_field))
 
+        term = self._convertDateTime(record.keys[0])
         if resultset is None:
             # Aggregate sets for each bucket separately, to avoid
             # large-small union penalties.
@@ -294,7 +280,7 @@ class DateRangeIndex(UnIndex):
             until = multiunion(self._until.values(term))
 
             # Total result is bound by resultset
-            if REQUEST is None:
+            if cache is None:
                 until = intersection(resultset, until)
 
             since = multiunion(self._since.values(None, term))
@@ -303,7 +289,7 @@ class DateRangeIndex(UnIndex):
             # Merge from smallest to largest.
             result = multiunion([bounded, until_only, since_only,
                                  self._always])
-            if REQUEST is not None and catalog is not None:
+            if cache is not None:
                 cache[cachekey] = result
 
             return (result, (self._since_field, self._until_field))
@@ -315,7 +301,7 @@ class DateRangeIndex(UnIndex):
             since = multiunion(self._since.values(term + 1))
 
             result = multiunion([since, since_only, until_only, until])
-            if REQUEST is not None and catalog is not None:
+            if cache is not None:
                 cache[cachekey] = result
 
             return (difference(resultset, result),
@@ -396,9 +382,9 @@ manage_addDateRangeIndexForm = DTMLFile('addDateRangeIndex', _dtmldir)
 
 
 def manage_addDateRangeIndex(self, id, extra=None,
-        REQUEST=None, RESPONSE=None, URL3=None):
+                             REQUEST=None, RESPONSE=None, URL3=None):
     """Add a date range index to the catalog, using the incredibly icky
        double-indirection-which-hides-NOTHING.
     """
     return self.manage_addIndex(id, 'DateRangeIndex', extra,
-        REQUEST, RESPONSE, URL3)
+                                REQUEST, RESPONSE, URL3)

--- a/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
+++ b/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
@@ -230,10 +230,6 @@ class DateRangeIndex(UnIndex):
 
     def getRequestCacheKey(self, record, resultset=None):
         term = self._convertDateTime(record.keys[0])
-
-        # why flatten to 10 minutes? 'term' is already flattened
-        # to minutes by _convertDateTime.
-        # tid = isinstance(term, int) and term / 10 or 'None'
         tid = str(term)
 
         # unique index identifier

--- a/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
+++ b/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
@@ -228,7 +228,7 @@ class DateRangeIndex(UnIndex):
                     else:
                         yield (key, len(value))
 
-    def _record_cache_key(self, record, resultset=None):
+    def getRequestCacheKey(self, record, resultset=None):
         term = self._convertDateTime(record.keys[0])
 
         # why flatten to 10 minutes? 'term' is already flattened
@@ -265,7 +265,7 @@ class DateRangeIndex(UnIndex):
 
         cache = self.getRequestCache()
         if cache is not None:
-            cachekey = self._record_cache_key(record, resultset)
+            cachekey = self.getRequestCacheKey(record, resultset)
             cached = cache.get(cachekey, None)
             if cached is not None:
                 if resultset is None:

--- a/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
+++ b/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py
@@ -282,11 +282,6 @@ class DateRangeIndex(UnIndex):
             until_only = multiunion(self._until_only.values(term))
             since_only = multiunion(self._since_only.values(None, term))
             until = multiunion(self._until.values(term))
-
-            # Total result is bound by resultset
-            if cache is None:
-                until = intersection(resultset, until)
-
             since = multiunion(self._since.values(None, term))
             bounded = intersection(until, since)
 

--- a/src/Products/PluginIndexes/DateRangeIndex/tests.py
+++ b/src/Products/PluginIndexes/DateRangeIndex/tests.py
@@ -38,22 +38,24 @@ class Dummy(object):
         return (self._start, self._stop)
 
 
-dummies = [ Dummy( 'a', None,   None )
-          , Dummy( 'b', None,   None )
-          , Dummy( 'c', 0,      None )
-          , Dummy( 'd', 10,     None )
-          , Dummy( 'e', None,   4    )
-          , Dummy( 'f', None,   11   )
-          , Dummy( 'g', 0,      11   )
-          , Dummy( 'h', 2,      9    )
-          ]
+dummies = [Dummy('a', None, None),
+           Dummy('b', None, None),
+           Dummy('c', 0, None),
+           Dummy('d', 10, None),
+           Dummy('e', None, 4),
+           Dummy('f', None, 11),
+           Dummy('g', 0, 11),
+           Dummy('h', 2, 9),
+           ]
 
 
 def matchingDummies(value):
     result = []
     for dummy in dummies:
-        if ((dummy.start() is None or dummy.start() <= value)
-            and (dummy.stop() is None or dummy.stop() >= value)):
+        if ((dummy.start() is None
+             or dummy.start() <= value) and
+            (dummy.stop() is None
+             or dummy.stop() >= value)):
             result.append(dummy)
     return result
 
@@ -86,7 +88,7 @@ class DRI_Tests(unittest.TestCase):
         empty = self._makeOne('empty')
 
         self.assertTrue(empty.getEntryForObject(1234) is None)
-        empty.unindex_object(1234) # shouldn't throw
+        empty.unindex_object(1234)  # shouldn't throw
 
         self.assertFalse(list(empty.uniqueValues('foo')))
         self.assertFalse(list(empty.uniqueValues('foo', withLengths=True)))
@@ -114,7 +116,8 @@ class DRI_Tests(unittest.TestCase):
             matches = sorted(matches, key=operator.methodcaller('name'))
 
             for result, match in map(None, results, matches):
-                self.assertEqual(index.getEntryForObject(result), match.datum())
+                self.assertEqual(index.getEntryForObject(result),
+                                 match.datum())
 
     def test_longdates(self):
         too_large = 2 ** 31
@@ -218,12 +221,14 @@ class DRI_Tests(unittest.TestCase):
         self.assertEqual(set(results), set([0, 1, 2, 3]))
 
         # a resultset with everything doesn't actually limit
-        results, used = index._apply_index({'work': 20},
+        results, used = index._apply_index(
+            {'work': 20},
             resultset=IISet(range(len(dummies))))
         self.assertEqual(set(results), set([0, 1, 2, 3]))
 
         # a small resultset limits
-        results, used = index._apply_index({'work': 20},
+        results, used = index._apply_index(
+            {'work': 20},
             resultset=IISet([1, 2]))
         self.assertEqual(set(results), set([1, 2]))
 
@@ -236,17 +241,20 @@ class DRI_Tests(unittest.TestCase):
         self.assertEqual(set(results), set([0, 1, 2, 3, 5, 6]))
 
         # the specified value is included with a large resultset
-        results, used = index._apply_index({'work': 11},
+        results, used = index._apply_index(
+            {'work': 11},
             resultset=IISet(range(len(dummies))))
         self.assertEqual(set(results), set([0, 1, 2, 3, 5, 6]))
 
         # this also works for _since_only
-        results, used = index._apply_index({'work': 10},
+        results, used = index._apply_index(
+            {'work': 10},
             resultset=IISet(range(len(dummies))))
         self.assertEqual(set(results), set([0, 1, 2, 3, 5, 6]))
 
         # the specified value is included with a small resultset
-        results, used = index._apply_index({'work': 11},
+        results, used = index._apply_index(
+            {'work': 11},
             resultset=IISet([0, 5, 7]))
         self.assertEqual(set(results), set([0, 5]))
 
@@ -318,7 +326,8 @@ class DRI_Cache_Tests(DRI_Tests):
         cache.clear()
 
         # first call
-        results_1, used = index._apply_index({'work': 20},
+        results_1, used = index._apply_index(
+            {'work': 20},
             resultset=IISet(range(len(dummies))))
         self.assertEqual(set(results_1), set([0, 1, 2, 3]))
         self.assertEqual(cache._hits, 0)
@@ -326,7 +335,8 @@ class DRI_Cache_Tests(DRI_Tests):
         self.assertEqual(cache._misses, 1)
 
         # second call
-        results_2, used = index._apply_index({'work': 20},
+        results_2, used = index._apply_index(
+            {'work': 20},
             resultset=IISet(range(len(dummies))))
         self.assertEqual(set(results_1), set(results_2))
         self.assertEqual(cache._hits, 1)

--- a/src/Products/PluginIndexes/FieldIndex/FieldIndex.py
+++ b/src/Products/PluginIndexes/FieldIndex/FieldIndex.py
@@ -34,8 +34,8 @@ class FieldIndex(UnIndex):
 manage_addFieldIndexForm = DTMLFile('dtml/addFieldIndex', globals())
 
 
-def manage_addFieldIndex(self, id, extra=None,
-                REQUEST=None, RESPONSE=None, URL3=None):
+def manage_addFieldIndex(self, id, extra=None, REQUEST=None,
+                         RESPONSE=None, URL3=None):
     """Add a field index"""
-    return self.manage_addIndex(id, 'FieldIndex', extra=extra, \
-             REQUEST=REQUEST, RESPONSE=RESPONSE, URL1=URL3)
+    return self.manage_addIndex(id, 'FieldIndex', extra=extra, REQUEST=REQUEST,
+                                RESPONSE=RESPONSE, URL1=URL3)

--- a/src/Products/PluginIndexes/FieldIndex/tests.py
+++ b/src/Products/PluginIndexes/FieldIndex/tests.py
@@ -253,6 +253,14 @@ class FieldIndexTests(unittest.TestCase):
 
 class FieldIndexCacheTests(FieldIndexTests):
 
+    def _dummy_test(self):
+        # dummy function
+        pass
+
+    # following methods do not require a cache test
+    test_interfaces = _dummy_test
+    test_getCounter = _dummy_test
+
     def _makeOne(self, id, extra=None):
 
         index = super(FieldIndexCacheTests, self).\

--- a/src/Products/PluginIndexes/FieldIndex/tests.py
+++ b/src/Products/PluginIndexes/FieldIndex/tests.py
@@ -108,11 +108,15 @@ class FieldIndexTests(unittest.TestCase):
         from Products.PluginIndexes.interfaces import IPluggableIndex
         from Products.PluginIndexes.interfaces import ISortIndex
         from Products.PluginIndexes.interfaces import IUniqueValueIndex
+        from Products.PluginIndexes.interfaces import IRequestCacheIndex
         from zope.interface.verify import verifyClass
 
-        verifyClass(IPluggableIndex, self._getTargetClass())
-        verifyClass(ISortIndex, self._getTargetClass())
-        verifyClass(IUniqueValueIndex, self._getTargetClass())
+        klass = self._getTargetClass()
+
+        verifyClass(IPluggableIndex, klass)
+        verifyClass(ISortIndex, klass)
+        verifyClass(IUniqueValueIndex, klass)
+        verifyClass(IRequestCacheIndex, klass)
 
     def testEmpty(self):
         "Test an empty FieldIndex."

--- a/src/Products/PluginIndexes/FieldIndex/tests.py
+++ b/src/Products/PluginIndexes/FieldIndex/tests.py
@@ -208,18 +208,15 @@ class FieldIndexTests(unittest.TestCase):
 
     def testReindex(self):
         self._populateIndex()
-        result, used = self._index._apply_index({'foo': 'abc'})
-        assert list(result) == [2]
+        self._checkApply({'foo': 'abc'}, [self._values[2], ])
         assert self._index.keyForDocument(2) == 'abc'
         d = Dummy('world')
         self._index.index_object(2, d)
-        result, used = self._index._apply_index({'foo': 'world'})
-        assert list(result) == [2]
+        self._checkApply({'foo': 'world'}, [(2, d), ])
         assert self._index.keyForDocument(2) == 'world'
         del d._foo
         self._index.index_object(2, d)
-        result, used = self._index._apply_index({'foo': 'world'})
-        assert list(result) == []
+        self._checkApply({'foo': 'world'}, [])
         try:
             should_not_be = self._index.keyForDocument(2)
         except KeyError:

--- a/src/Products/PluginIndexes/FieldIndex/tests.py
+++ b/src/Products/PluginIndexes/FieldIndex/tests.py
@@ -54,29 +54,32 @@ class FieldIndexTests(unittest.TestCase):
             keys = self._forward.get(v, [])
             self._forward[v] = keys
 
-        self._noop_req  = {'bar': 123}
-        self._request   = {'foo': 'abce'}
-        self._min_req   = {'foo':
-            {'query': 'abc', 'range': 'min'}}
-        self._min_req_n = {'foo':
-            {'query': 'abc', 'range': 'min', 'not': 'abca'}}
-        self._max_req   = {'foo':
-            {'query': 'abc', 'range': 'max'}}
-        self._max_req_n = {'foo':
-            {'query': 'abc', 'range': 'max', 'not': ['a', 'b', 0]}}
-        self._range_req = {'foo':
-            {'query': ('abc', 'abcd'), 'range': 'min:max'}}
-        self._range_ren = {'foo':
-            {'query': ('abc', 'abcd'), 'range': 'min:max', 'not': 'abcd'}}
-        self._range_non = {'foo':
-            {'query': ('a', 'aa'), 'range': 'min:max', 'not': 'a'}}
-        self._zero_req  = {'foo': 0 }
-        self._not_1     = {'foo': {'query': 'a', 'not': 'a'}}
-        self._not_2     = {'foo': {'query': ['a', 'ab'], 'not': 'a'}}
-        self._not_3     = {'foo': {'not': 'a'}}
-        self._not_4     = {'foo': {'not': [0]}}
-        self._not_5     = {'foo': {'not': ['a', 'b']}}
-        self._not_6     = {'foo': 'a', 'bar': {'query': 123, 'not': 1}}
+        self._noop_req = {'bar': 123}
+        self._request = {'foo': 'abce'}
+        self._min_req = {'foo': {'query': 'abc', 'range': 'min'}}
+        self._min_req_n = {'foo': {'query': 'abc',
+                                   'range': 'min',
+                                   'not': 'abca'}}
+        self._max_req = {'foo': {'query': 'abc',
+                                 'range': 'max'}}
+        self._max_req_n = {'foo': {'query': 'abc',
+                                   'range': 'max',
+                                   'not': ['a', 'b', 0]}}
+        self._range_req = {'foo': {'query': ('abc', 'abcd'),
+                                   'range': 'min:max'}}
+        self._range_ren = {'foo': {'query': ('abc', 'abcd'),
+                                   'range': 'min:max',
+                                   'not': 'abcd'}}
+        self._range_non = {'foo': {'query': ('a', 'aa'),
+                                   'range': 'min:max',
+                                   'not': 'a'}}
+        self._zero_req = {'foo': 0}
+        self._not_1 = {'foo': {'query': 'a', 'not': 'a'}}
+        self._not_2 = {'foo': {'query': ['a', 'ab'], 'not': 'a'}}
+        self._not_3 = {'foo': {'not': 'a'}}
+        self._not_4 = {'foo': {'not': [0]}}
+        self._not_5 = {'foo': {'not': ['a', 'b']}}
+        self._not_6 = {'foo': 'a', 'bar': {'query': 123, 'not': 1}}
 
     def _populateIndex(self):
         for k, v in self._values:
@@ -88,7 +91,7 @@ class FieldIndexTests(unittest.TestCase):
             result = result.keys()
         assert used == ('foo', )
         assert len(result) == len(expectedValues), \
-          '%s | %s' % (map(None, result), expectedValues)
+            '%s | %s' % (map(None, result), expectedValues)
         for k, v in expectedValues:
             assert k in result
 
@@ -111,7 +114,7 @@ class FieldIndexTests(unittest.TestCase):
 
         assert self._index.getEntryForObject(1234) is None
         assert (self._index.getEntryForObject(1234, self._marker)
-                  is self._marker)
+                is self._marker)
         self._index.unindex_object(1234)  # nothrow
 
         assert self._index.hasUniqueValuesFor('foo')
@@ -134,12 +137,12 @@ class FieldIndexTests(unittest.TestCase):
         values = self._values
 
         assert len(self._index) == len(values) - 1  # 'abce' is duplicate
-        assert len(self._index.referencedObjects() ) == len(values)
+        assert len(self._index.referencedObjects()) == len(values)
         self.assertEqual(self._index.indexSize(), len(values) - 1)
 
         assert self._index.getEntryForObject(1234) is None
         assert (self._index.getEntryForObject(1234, self._marker)
-                  is self._marker)
+                is self._marker)
         self._index.unindex_object(1234)  # nothrow
 
         for k, v in values:

--- a/src/Products/PluginIndexes/KeywordIndex/tests.py
+++ b/src/Products/PluginIndexes/KeywordIndex/tests.py
@@ -64,7 +64,7 @@ class TestKeywordIndex(unittest.TestCase):
                         (5, Dummy(['a', 'b', 'c', 'e'])),
                         (6, Dummy(['a', 'b', 'c', 'e', 'f'])),
                         (7, Dummy([0])),
-                       ]
+                        ]
         self._noop_req = {'bar': 123}
         self._all_req = {'foo': ['a']}
         self._some_req = {'foo': ['e']}
@@ -173,32 +173,22 @@ class TestKeywordIndex(unittest.TestCase):
 
     def testReindexChange(self):
         self._populateIndex()
+        values = self._values
+
         expected = Dummy(['x', 'y'])
         self._index.index_object(6, expected)
-        result, used = self._index._apply_index({'foo': ['x', 'y']})
-        result = result.keys()
-        assert len(result) == 1
-        assert result[0] == 6
-        result, used = self._index._apply_index(
-            {'foo': ['a', 'b', 'c', 'e', 'f']})
-        result = result.keys()
-        assert 6 not in result
+        self._checkApply({'foo': ['x', 'y']}, [(6, expected), ])
+        self._checkApply({'foo': ['a', 'b', 'c', 'e', 'f']}, values[:6])
 
     def testReindexNoChange(self):
         self._populateIndex()
         expected = Dummy(['foo', 'bar'])
+
         self._index.index_object(8, expected)
-        result, used = self._index._apply_index(
-            {'foo': ['foo', 'bar']})
-        result = result.keys()
-        assert len(result) == 1
-        assert result[0] == 8
+        self._checkApply({'foo': ['foo', 'bar']}, [(8, expected), ])
+
         self._index.index_object(8, expected)
-        result, used = self._index._apply_index(
-            {'foo': ['foo', 'bar']})
-        result = result.keys()
-        assert len(result) == 1
-        assert result[0] == 8
+        self._checkApply({'foo': ['foo', 'bar']}, [(8, expected), ])
 
     def testIntersectionWithRange(self):
         # Test an 'and' search, ensuring that 'range' doesn't mess it up.
@@ -290,6 +280,20 @@ class TestKeywordIndex(unittest.TestCase):
 
 
 class TestKeywordIndexCache(TestKeywordIndex):
+
+    def _dummy_test(self):
+        # dummy function
+        pass
+
+    # following methods do not require a cache test
+    test_interfaces = _dummy_test
+    testAddObjectWOKeywords = _dummy_test
+    testDuplicateKeywords = _dummy_test
+    test_noindexing_when_noattribute = _dummy_test
+    test_noindexing_when_raising_attribute = _dummy_test
+    test_noindexing_when_raising_typeeror = _dummy_test
+    test_value_removes = _dummy_test
+    test_getCounter = _dummy_test
 
     def _makeOne(self, id, extra=None):
 

--- a/src/Products/PluginIndexes/UUIDIndex/UUIDIndex.py
+++ b/src/Products/PluginIndexes/UUIDIndex/UUIDIndex.py
@@ -93,10 +93,10 @@ class UUIDIndex(UnIndex):
             self._length.change(1)
         elif old_docid != documentId:
             logger.error("A different document with value '%s' already "
-                "exists in the index.'" % entry)
+                         "exists in the index.'" % entry)
 
     def removeForwardIndexEntry(self, entry, documentId):
-        """Take the entry provided and remove any reference to documentId
+        """Take the entry parovided and remove any reference to documentId
         in its entry in the index.
         """
         old_docid = self._index.get(entry, _marker)
@@ -116,7 +116,7 @@ manage_addUUIDIndexForm = DTMLFile('dtml/addUUIDIndex', globals())
 
 
 def manage_addUUIDIndex(self, id, extra=None,
-                REQUEST=None, RESPONSE=None, URL3=None):
+                        REQUEST=None, RESPONSE=None, URL3=None):
     """Add an uuid index"""
-    return self.manage_addIndex(id, 'UUIDIndex', extra=extra, \
-             REQUEST=REQUEST, RESPONSE=RESPONSE, URL1=URL3)
+    return self.manage_addIndex(id, 'UUIDIndex', extra=extra,
+                                REQUEST=REQUEST, RESPONSE=RESPONSE, URL1=URL3)

--- a/src/Products/PluginIndexes/UUIDIndex/tests.py
+++ b/src/Products/PluginIndexes/UUIDIndex/tests.py
@@ -13,7 +13,8 @@
 
 import unittest
 
-from Products.PluginIndexes.UUIDIndex.UUIDIndex import UUIDIndex
+from OFS.SimpleItem import SimpleItem
+from Testing.makerequest import makerequest
 
 
 class Dummy:
@@ -32,8 +33,17 @@ class Dummy:
 
 class UUIDIndexTests(unittest.TestCase):
 
+    def _getTargetClass(self):
+        from Products.PluginIndexes.UUIDIndex.UUIDIndex \
+            import UUIDIndex
+        return UUIDIndex
+
+    def _makeOne(self, id):
+        klass = self._getTargetClass()
+        return klass(id)
+
     def setUp(self):
-        self._index = UUIDIndex('foo')
+        self._index = self._makeOne('foo')
         self._marker = []
         self._values = [
             (0, Dummy('a')),
@@ -68,11 +78,15 @@ class UUIDIndexTests(unittest.TestCase):
         from Products.PluginIndexes.interfaces import IPluggableIndex
         from Products.PluginIndexes.interfaces import ISortIndex
         from Products.PluginIndexes.interfaces import IUniqueValueIndex
+        from Products.PluginIndexes.interfaces import IRequestCacheIndex
         from zope.interface.verify import verifyClass
 
-        verifyClass(IPluggableIndex, UUIDIndex)
-        verifyClass(ISortIndex, UUIDIndex)
-        verifyClass(IUniqueValueIndex, UUIDIndex)
+        klass = self._getTargetClass()
+
+        verifyClass(IPluggableIndex, klass)
+        verifyClass(ISortIndex, klass)
+        verifyClass(IUniqueValueIndex, klass)
+        verifyClass(IRequestCacheIndex, klass)
 
     def test_empty(self):
         self.assertEqual(len(self._index), 0)
@@ -88,7 +102,7 @@ class UUIDIndexTests(unittest.TestCase):
         self.assertTrue(self._index.getEntryForObject(10) is None)
         self._checkApply({'foo': 'not'}, [])
 
-        self._index.unindex_object(10) # nothrow
+        self._index.unindex_object(10)  # nothrow
 
         for k, v in values:
             self.assertEqual(self._index.getEntryForObject(k), v.foo())
@@ -163,3 +177,51 @@ class UUIDIndexTests(unittest.TestCase):
 
         index.clear()
         self.assertEqual(index.getCounter(), 0)
+
+
+class UUIDIndexTestsCache(UUIDIndexTests):
+
+    def _dummy_test(self):
+        # dummy function
+        pass
+
+    # not required for cache test
+    test_interfaces = _dummy_test
+    test_getCounter = _dummy_test
+
+    def _makeOne(self, id, extra=None):
+
+        index = super(UUIDIndexTestsCache, self).\
+            _makeOne(id)
+
+        class DummyZCatalog(SimpleItem):
+            id = 'DummyZCatalog'
+
+        # Build pseudo catalog and REQUEST environment
+        catalog = makerequest(DummyZCatalog())
+        indexes = SimpleItem()
+
+        indexes = indexes.__of__(catalog)
+        index = index.__of__(indexes)
+
+        return index
+
+    def _checkApply(self, req, expectedValues):
+
+        checkApply = super(UUIDIndexTestsCache, self)._checkApply
+        index = self._index
+
+        cache = index.getRequestCache()
+        cache.clear()
+
+        # first call
+        checkApply(req, expectedValues)
+        self.assertEqual(cache._hits, 0)
+        self.assertEqual(cache._sets, 1)
+        self.assertEqual(cache._misses, 1)
+
+        # second call
+        checkApply(req, expectedValues)
+        self.assertEqual(cache._hits, 1)
+
+ 

--- a/src/Products/PluginIndexes/common/UnIndex.py
+++ b/src/Products/PluginIndexes/common/UnIndex.py
@@ -455,11 +455,13 @@ class UnIndex(SimpleItem):
                         cached = r
 
                 if cached is not None:
+                    if isinstance(cached, int):
+                        cached = IISet((cached, ))
+
                     if not_parm:
                         not_parm = map(self._convert, not_parm)
                         exclude = self._apply_not(not_parm, resultset)
-                        r = difference(cached, exclude)
-                        return r, (self.id,)
+                        cached = difference(cached, exclude)
 
                     return cached, (self.id,)
 

--- a/src/Products/PluginIndexes/common/UnIndex.py
+++ b/src/Products/PluginIndexes/common/UnIndex.py
@@ -359,7 +359,7 @@ class UnIndex(SimpleItem):
         params.append(('operator', operator))
 
         # not / exclude operator
-        not_value = getattr(self, 'not', None)
+        not_value = record.get('not', None)
         if not_value is not None:
             not_value = frozenset(not_value)
             params.append(('not', not_value))
@@ -380,7 +380,6 @@ class UnIndex(SimpleItem):
         # unique index identifier
         iid = '_%s_%s_%s' % (self.__class__.__name__,
                              self.id, self.getCounter())
-
         return (iid, rid)
 
     def _apply_index(self, request, resultset=None):

--- a/src/Products/PluginIndexes/common/tests/test_UnIndex.py
+++ b/src/Products/PluginIndexes/common/tests/test_UnIndex.py
@@ -13,6 +13,10 @@
 
 import unittest
 
+from OFS.SimpleItem import SimpleItem
+from Testing.makerequest import makerequest
+from BTrees.IIBTree import difference
+
 
 class UnIndexTests(unittest.TestCase):
 
@@ -21,7 +25,19 @@ class UnIndexTests(unittest.TestCase):
         return UnIndex
 
     def _makeOne(self, *args, **kw):
-        return self._getTargetClass()(*args, **kw)
+        index = self._getTargetClass()(*args, **kw)
+
+        class DummyZCatalog(SimpleItem):
+            id = 'DummyZCatalog'
+
+        # Build pseudo catalog and REQUEST environment
+        catalog = makerequest(DummyZCatalog())
+        indexes = SimpleItem()
+
+        indexes = indexes.__of__(catalog)
+        index = index.__of__(indexes)
+
+        return index
 
     def _makeConflicted(self):
         from ZODB.POSException import ConflictError
@@ -77,6 +93,53 @@ class UnIndexTests(unittest.TestCase):
 
         dummy.exc = TypeError
         self.assertEquals(idx._get_object_datum(dummy, 'interesting'), _marker)
+
+    def test_cache(self):
+        idx = self._makeOne(id='foo')
+        idx.query_options = ('query', 'range', 'not', 'operator')
+
+        def testQuery(record, expect=1):
+            cache = idx.getRequestCache()
+            cache.clear()
+
+            # First query
+            res1 = idx._apply_index(record)
+
+            # Cache set?
+            self.assertEqual(cache._sets, expect)
+
+            # Cache miss?
+            self.assertEqual(cache._misses, expect)
+
+            # Second Query
+            res2 = idx._apply_index(record)
+
+            # Cache hit?
+            self.assertEqual(cache._hits, expect)
+
+            # Check if result of second query is equal to first query
+            result = difference(res1[0], res2[0])
+            self.assertEqual(len(result), 0)
+
+        # Dummy tests, result is always empty.
+        # TODO: Sophisticated tests have to be placed on tests
+        # of inherited classes (FieldIndex, KeywordIndex etc.)
+        #
+        # 'or' operator
+        record = {'foo': {'query': ['e', 'f'], 'operator': 'or'}}
+        testQuery(record)
+
+        # 'and' operator (currently not supported)
+        record = {'foo': {'query': ['e', 'f'], 'operator': 'and'}}
+        testQuery(record)
+
+        # 'range' option
+        record = {'foo': {'query': ('abc', 'abcd'), 'range': 'min:max'}}
+        testQuery(record)
+
+        # 'not' option
+        record = {'foo': {'query': ['a', 'ab'], 'not': 'a'}}
+        testQuery(record)
 
     def test_getCounter(self):
         index = self._makeOne('counter')

--- a/src/Products/PluginIndexes/common/util.py
+++ b/src/Products/PluginIndexes/common/util.py
@@ -41,11 +41,12 @@ class parseIndexRequest:
 
       other parameters depend on the the index
 
-   - record-style parameters specify a query for an index as instance of the
-     Record class. This happens usually when parameters from a web form use
-     the "record" type e.g. <input type="text" name="path.query:record:string">.
-     All restrictions of the dictionary-style parameters apply to the record-style
-     parameters
+   - record-style parameters specify a query for an index as instance
+     of the Record class. This happens usually when parameters from a
+     web form use the "record" type e.g.
+           <input type="text" name="path.query:record:string">.
+     All restrictions of the dictionary-style parameters apply to the
+     record-style parameters
     """
 
     ParserException = IndexRequestParseError
@@ -60,7 +61,7 @@ class parseIndexRequest:
         """
 
         self.id = iid
-        if not request.has_key(iid):
+        if iid not in request:
             self.keys = None
             return
 
@@ -82,7 +83,8 @@ class parseIndexRequest:
                 keys = [keys.strip()]
 
             for op in options:
-                if op == "query": continue
+                if op == "query":
+                    continue
 
                 if hasattr(record, op):
                     setattr(self, op, getattr(record, op))
@@ -94,12 +96,13 @@ class parseIndexRequest:
             if isinstance(query, (tuple, list)):
                 keys = query
             else:
-                keys = [ query ]
+                keys = [query]
 
             for op in options:
-                if op == "query": continue
+                if op == "query":
+                    continue
 
-                if param.has_key(op):
+                if op in param:
                     setattr(self, op, param[op])
 
         else:
@@ -112,7 +115,7 @@ class parseIndexRequest:
 
             for op in options:
                 field = iid + "_" + op
-                if request.has_key(field):
+                if field in request:
                     setattr(self, op, request[field])
 
         self.keys = keys

--- a/src/Products/PluginIndexes/interfaces.py
+++ b/src/Products/PluginIndexes/interfaces.py
@@ -233,6 +233,7 @@ class ITopicIndex(Interface):
 # order to perform introspection on indexes in a defined way.
 # (ajung)
 
+
 class IIndexConfiguration(Interface):
     """ Introspection API for pluggable indexes """
 
@@ -241,3 +242,16 @@ class IIndexConfiguration(Interface):
             E.g. {'indexed_attrs' : ('SearchableText', )}.
             The interface does not define any specifc mapping keys.
         """
+
+
+class IRequestCacheIndex(Interface):
+    """ Request cache API for pluggable indexes """
+
+    def getRequestCache():
+        """ Returns dict for caching per request for interim results
+            of an index search. Returns 'None' if no REQUEST attribute
+            is available
+        """
+
+    def getRequestCacheKey(record, resultset=None):
+        """ Returns an unique key of a search record """


### PR DESCRIPTION
@hannosch 

I have now reimplemented the ideas of PR #9 based on the new getCounter logic. IMO, there are still open questions:
- Do we need an interface for the caching logic? Benefit?
- Should an index share a common dict per zcatalog for caching (as implemented) with the other indexes or should each index use its own dict?
- There are outstanding tests in order to check the functionality of the derived indexes. See example in [DateRangeIndex/tests.py](https://github.com/zopefoundation/Products.ZCatalog/compare/andbag-unindex-requestcache#diff-4b0783d021834f79034ac5ed35066ba7R273) (l. 273)

Last but not least, I need some feedback of you all. :)