### PR TITLE
Precision property for DateIndex and DateRangeIndex

### DIFF
--- a/src/Products/PluginIndexes/DateIndex/DateIndex.py
+++ b/src/Products/PluginIndexes/DateIndex/DateIndex.py
@@ -1,4 +1,4 @@
-##############################################################################
+#############################################################################
 #
 # Copyright (c) 2002 Zope Foundation and Contributors.
 #
@@ -85,8 +85,12 @@ class DateIndex(UnIndex, PropertyManager):
     query_options = ('query', 'range', 'not')
 
     index_naive_time_as_local = True  # False means index as UTC
+    precision = 1  # precsion of indexed time in minutes
     _properties = ({'id': 'index_naive_time_as_local',
                     'type': 'boolean',
+                    'mode': 'w'},
+                   {'id': 'precision',
+                    'type': 'int',
                     'mode': 'w'},)
 
     manage = manage_main = DTMLFile('dtml/manageDateIndex', globals())
@@ -175,6 +179,13 @@ class DateIndex(UnIndex, PropertyManager):
         mn = t_tup[4]
 
         t_val = ((((yr * 12 + mo) * 31 + dy) * 24 + hr) * 60 + mn)
+
+        # flatten to precision
+        precision = self.precision
+        if precision > 1:
+            t_val = t_val - (t_val % precision)
+
+        t_val = int(t_val)
 
         if t_val > MAX32:
             # t_val must be integer fitting in the 32bit range

--- a/src/Products/PluginIndexes/DateIndex/tests.py
+++ b/src/Products/PluginIndexes/DateIndex/tests.py
@@ -108,7 +108,7 @@ class DateIndexTests(unittest.TestCase):
         from Products.PluginIndexes.DateIndex.DateIndex import DateIndex
         return DateIndex
 
-    def _makeOne(self, id='date'):
+    def _makeOne(self, id='date', precision=1):
         index = self._getTargetClass()(id)
         class DummyZCatalog(SimpleItem):
             id = 'DummyZCatalog'
@@ -119,6 +119,9 @@ class DateIndexTests(unittest.TestCase):
 
         indexes = indexes.__of__(catalog)
         index = index.__of__(indexes)
+
+        if precision > 1:
+            index.manage_changeProperties(precision=precision)
 
         return index
 
@@ -154,7 +157,9 @@ class DateIndexTests(unittest.TestCase):
                 result = result.keys()
             self.assertEqual(used, ('date',))
             self.assertEqual(len(result), len(expectedValues),
-                             '%s | %s' % (result, expectedValues))
+                             '%s: %s | %s' %
+                             (req, map(None, result),
+                              map(lambda x: x[0], expectedValues)))
             for k, v in expectedValues:
                 self.assertTrue(k in result)
 
@@ -171,7 +176,7 @@ class DateIndexTests(unittest.TestCase):
         checkApply()
         self.assertEqual(cache._hits, 1)
 
-    def _convert(self, dt):
+    def _convert(self, dt, precision=1):
         from time import gmtime
         from datetime import date
         from datetime import datetime
@@ -186,7 +191,10 @@ class DateIndexTests(unittest.TestCase):
             yr, mo, dy, hr, mn = dt.utctimetuple()[:5]
         else:
             yr, mo, dy, hr, mn = dt.toZone('UTC').parts()[:5]
-        return (((yr * 12 + mo) * 31 + dy) * 24 + hr) * 60 + mn
+        value = (((yr * 12 + mo) * 31 + dy) * 24 + hr) * 60 + mn
+        if precision > 1:
+            value = value - (value % precision)
+        return int(value)
 
     def test_interfaces(self):
         from Products.PluginIndexes.interfaces import IDateIndex
@@ -280,6 +288,7 @@ class DateIndexTests(unittest.TestCase):
                                     DateTime('2062-05-08 15:16:17')),
                                    'range': 'min:max'}},
                          values[2:])
+
         self._checkApply(index,
                          {'date': 1072742620.0}, [values[6]])
         self._checkApply(index,
@@ -343,3 +352,29 @@ class DateIndexTests(unittest.TestCase):
 
         index.clear()
         self.assertEqual(index.getCounter(), 0)
+
+    def test_precision(self):
+        from DateTime import DateTime
+        precision = 5
+        index = self._makeOne(precision=precision)
+        self._populateIndex(index)
+        values = self._getValues()
+        for k, v in values:
+            if v.date():
+                self.assertEqual(index.getEntryForObject(k),
+                                 self._convert(v.date(), precision))
+        self._checkApply(index,
+                         {'date': DateTime(0)}, values[1:2])
+        self._checkApply(index,
+                         {'date': {'query': DateTime('2032-05-08 15:16:17'),
+                                   'range': 'min'}},
+                         values[3:6] + values[8:])
+        self._checkApply(index,
+                         {'date': {'query': DateTime('2032-05-08 15:16:17'),
+                                   'range': 'max'}},
+                         values[1:4] + values[6:8])
+
+        self._checkApply(index,
+                         {'date': 1072742620.0}, [values[6]])
+        self._checkApply(index,
+                         {'date': 1072742900}, [values[7]])

--- a/src/Products/PluginIndexes/DateRangeIndex/dtml/addDateRangeIndex.dtml
+++ b/src/Products/PluginIndexes/DateRangeIndex/dtml/addDateRangeIndex.dtml
@@ -62,6 +62,16 @@ objects for those where a given date falls within the range.
    <input type="text" name="extra.ceiling_value:record" size="15" />
   </td>
  </tr>
+ <tr>
+  <td align="left" valign="top">
+  <div class="form-label">
+  Precision value
+  </div>
+  </td>
+  <td align="left" valign="top">
+   <input type="text" name="extra.precision_value:record" size="15" />
+  </td>
+ </tr>
   <tr>
     <td align="left" valign="top">
     </td>

--- a/src/Products/PluginIndexes/DateRangeIndex/dtml/manageDateRangeIndex.dtml
+++ b/src/Products/PluginIndexes/DateRangeIndex/dtml/manageDateRangeIndex.dtml
@@ -51,6 +51,15 @@ Distinct values: <dtml-var indexSize>
   </td>
 </tr>
 <tr>
+  <td align="left" valign="top">
+  <div class="form-label">
+  Precision value
+  </td>
+  <td align="left" valign="top">
+   <input name="precision_value" value="&dtml-getPrecisionValue;" />
+  </td>
+</tr>
+<tr>
   <td></td>
   <td align="left" valign="top">
   <div class="form-element">

--- a/src/Products/PluginIndexes/DateRangeIndex/tests.py
+++ b/src/Products/PluginIndexes/DateRangeIndex/tests.py
@@ -332,7 +332,7 @@ class DateRangeIndexTests(unittest.TestCase):
         for value in range(-1, 15):
             matches = matchingDummiesByTimeValue(value, precision)
             results, used = self._checkApply(index, {'work': value}, matches)
-            matches = sorted(matches, key=lambda d: d[1].name)
+            matches = sorted(matches, key=lambda d: d[1].name())
             for result, match in map(None, results, matches):
                 datum = map(lambda d: convertDateTime(d, precision),
                             match[1].datum())

--- a/src/Products/PluginIndexes/DateRangeIndex/tests.py
+++ b/src/Products/PluginIndexes/DateRangeIndex/tests.py
@@ -12,7 +12,8 @@
 ##############################################################################
 
 import unittest
-
+from datetime import datetime
+from DateTime.DateTime import DateTime
 from BTrees.IIBTree import IISet
 from OFS.SimpleItem import SimpleItem
 from Testing.makerequest import makerequest
@@ -49,17 +50,37 @@ dummies = [(0, Dummy('a', None, None)),
            ]
 
 
-def matchingDummiesByTimeValue(value):
+def matchingDummiesByTimeValue(value, precision=1):
     result = []
+    value = convertDateTime(value, precision)
     for i, dummy in dummies:
-        if ((dummy.start() is None or dummy.start() <= value) and
-                (dummy.stop() is None or dummy.stop() >= value)):
+        start = convertDateTime(dummy.start(), precision)
+        stop = convertDateTime(dummy.stop(), precision)
+        if ((start is None or start <= value) and
+                (stop is None or stop >= value)):
             result.append((i, dummy))
     return result
 
 
 def matchingDummiesByUIDs(uids):
     return [(i, dummies[i]) for i in uids]
+
+
+def convertDateTime(value, precision=1):
+    if value is None:
+        return value
+    if isinstance(value, (str, datetime)):
+        dt_obj = DateTime(value)
+        value = dt_obj.millis() / 1000 / 60  # flatten to minutes
+    elif isinstance(value, DateTime):
+        value = value.millis() / 1000 / 60  # flatten to minutes
+
+    # flatten to precision
+    if precision > 1:
+        value = value - (value % precision)
+
+    value = int(value)
+    return value
 
 
 class DateRangeIndexTests(unittest.TestCase):
@@ -69,10 +90,11 @@ class DateRangeIndexTests(unittest.TestCase):
             import DateRangeIndex
         return DateRangeIndex
 
-    def _makeOne(self, id, since_field=None, until_field=None, caller=None,
-                 extra=None):
+    def _makeOne(self, id, since_field=None, until_field=None,
+                 caller=None, extra=None, precision_value=None):
         klass = self._getTargetClass()
-        index = klass(id, since_field, until_field, caller, extra)
+        index = klass(id, since_field, until_field, caller, extra,
+                      precision_value=precision_value)
 
         class DummyZCatalog(SimpleItem):
             id = 'DummyZCatalog'
@@ -94,7 +116,8 @@ class DateRangeIndexTests(unittest.TestCase):
                 result = result.keys()
             assert used == (index._since_field, index._until_field)
             assert len(result) == len(expectedValues), \
-                '%s | %s' % (map(None, result), expectedValues)
+                '%s: %s | %s' % (req, map(None, result),
+                                 map(lambda x: x[0], expectedValues))
             for k, v in expectedValues:
                 assert k in result
             return result, used
@@ -179,8 +202,6 @@ class DateRangeIndexTests(unittest.TestCase):
         self.assertTrue(1 in index._always.keys())
 
     def test_datetime(self):
-        from datetime import datetime
-        from DateTime.DateTime import DateTime
         from Products.PluginIndexes.DateIndex.tests import _getEastern
         before = datetime(2009, 7, 11, 0, 0, tzinfo=_getEastern())
         start = datetime(2009, 7, 13, 5, 15, tzinfo=_getEastern())
@@ -208,8 +229,6 @@ class DateRangeIndexTests(unittest.TestCase):
         self._checkApply(index, {'work': after}, [])
 
     def test_datetime_naive_timezone(self):
-        from datetime import datetime
-        from DateTime.DateTime import DateTime
         from Products.PluginIndexes.DateIndex.DateIndex import Local
         before = datetime(2009, 7, 11, 0, 0)
         start = datetime(2009, 7, 13, 5, 15)
@@ -296,3 +315,26 @@ class DateRangeIndexTests(unittest.TestCase):
 
         index.clear()
         self.assertEqual(index.getCounter(), 0)
+
+    def test_precision(self):
+        precision = 5
+        index = self._makeOne('work', 'start', 'stop',
+                              precision_value=precision)
+
+        for i, dummy in dummies:
+            index.index_object(i, dummy)
+
+        for i, dummy in dummies:
+            datum = map(lambda d: convertDateTime(d, precision),
+                        dummy.datum())
+            self.assertEqual(index.getEntryForObject(i), tuple(datum))
+
+        for value in range(-1, 15):
+            matches = matchingDummiesByTimeValue(value, precision)
+            results, used = self._checkApply(index, {'work': value}, matches)
+            matches = sorted(matches, key=lambda d: d[1].name)
+            for result, match in map(None, results, matches):
+                datum = map(lambda d: convertDateTime(d, precision),
+                            match[1].datum())
+                self.assertEqual(index.getEntryForObject(result),
+                                 tuple(datum))


### PR DESCRIPTION
The effectiveness of date index caching can be strongly increased if the index would factor in the precision of the indexed time values. For example, the time precision of the indexed attributes "start", "end", "expires" and "effective" has a precision abut 5 minutes in Plone. There is no requirement to consider a higher precision for the indexing of these attributes. The default precision is currently one minute and is not configurable. Depending on the applied query values the TTL of the cache key can be shorter than necessary (e.g. for the "effectiveRange" index in Plone). The PR implements a configurable precision property incl. tests for the Date- and DateRangeIndex.
