### PR TITLE
Use aq_inner before aq_parent at some places to safely get the parent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.0a4 (unreleased)
 ------------------
 
+- Use aq_inner before aq_parent at some places to safely get the parent
+  [MrTango]
+
 
 4.0a3 (2017-02-02)
 ------------------

--- a/src/Products/ZCatalog/CatalogBrains.py
+++ b/src/Products/ZCatalog/CatalogBrains.py
@@ -14,6 +14,7 @@
 from Acquisition import aq_base
 from Acquisition import aq_get
 from Acquisition import aq_parent
+from Acquisition import aq_inner
 from Acquisition import Implicit
 from Record import Record
 from zope.globalrequest import getRequest
@@ -38,7 +39,7 @@ class AbstractCatalogBrain(Record, Implicit):
 
     def getPath(self):
         """Get the physical path for this record"""
-        return aq_parent(self).getpath(self.data_record_id_)
+        return aq_parent(aq_inner(self)).getpath(self.data_record_id_)
 
     def getURL(self, relative=0):
         """Generate a URL for this record"""

--- a/src/Products/ZCatalog/ZCatalogIndexes.py
+++ b/src/Products/ZCatalog/ZCatalogIndexes.py
@@ -17,6 +17,7 @@ from AccessControl.class_init import InitializeClass
 from AccessControl.SecurityInfo import ClassSecurityInfo
 from AccessControl.Permissions import manage_zcatalog_indexes
 from Acquisition import aq_base
+from Acquisition import aq_inner
 from Acquisition import aq_parent
 from Acquisition import Implicit
 from App.special_dtml import DTMLFile
@@ -65,14 +66,14 @@ class ZCatalogIndexes(IFAwareObjectManager, Folder, Persistent, Implicit):
         aq_base(aq_parent(self))._indexes = indexes
 
     def _getOb(self, id, default=_marker):
-        indexes = aq_parent(self)._catalog.indexes
+        indexes = aq_parent(aq_inner(self))._catalog.indexes
         if default is _marker:
             return indexes.get(id)
         return indexes.get(id, default)
 
     security.declareProtected(manage_zcatalog_indexes, 'objectIds')
     def objectIds(self, spec=None):
-        indexes = aq_parent(self)._catalog.indexes
+        indexes = aq_parent(aq_inner(self))._catalog.indexes
         if spec is not None:
             if isinstance(spec, str):
                 spec = [spec]
@@ -104,6 +105,7 @@ class ZCatalogIndexes(IFAwareObjectManager, Folder, Persistent, Implicit):
             return o.__of__(self)
 
         return getattr(self, name)
+
 
 InitializeClass(ZCatalogIndexes)
 


### PR DESCRIPTION
This fixes some errors in ZMI views catalog views like: https://github.com/plone/Products.CMFPlone/issues/1928