### PR TITLE
Add new `getAllBrains` method to the ZCatalog.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 3.5
     - 3.6
 install:
+    - pip install six==1.10.0 # force here to avoid conflit with zc.recipe.testrunner
     - pip install -U setuptools==33.1.1
     - pip install zc.buildout
     - buildout bootstrap

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 4.0.2 (unreleased)
 ------------------
 
+- Add new `getAllBrains` method to the ZCatalog, returning a generator
+  of brains for all cataloged objects. You can use this if you relied
+  on `searchResults` returning all brains for empty queries before
+  version 4.0a2.
 
 4.0.1 (2017-10-10)
 ------------------

--- a/src/Products/ZCatalog/ZCatalog.py
+++ b/src/Products/ZCatalog/ZCatalog.py
@@ -554,6 +554,12 @@ class ZCatalog(Folder, Persistent, Implicit):
         # return the current index contents for the specific rid
         return self._catalog.getIndexDataForRID(rid)
 
+    security.declareProtected(search_zcatalog, 'getAllBrains')
+    def getAllBrains(self):
+        # return a generator of brains for all cataloged objects
+        for rid in self._catalog.data:
+            yield self._catalog[rid]
+
     security.declareProtected(search_zcatalog, 'schema')
     def schema(self):
         return self._catalog.schema.keys()

--- a/src/Products/ZCatalog/tests/test_catalog.py
+++ b/src/Products/ZCatalog/tests/test_catalog.py
@@ -232,9 +232,39 @@ class TestCatalog(unittest.TestCase):
             catalog.catalogObject(Dummy(self.nums[x]), repr(x))
         return catalog.__of__(Dummy('foo'))
 
-    # clear
+    def test_clear(self):
+        catalog = self._make_one()
+        self.assertTrue(len(catalog) > 0)
+        catalog.clear()
+        self.assertEqual(catalog._length(), 0)
+        self.assertEqual(len(catalog), 0)
+        self.assertEqual(len(catalog.data), 0)
+        self.assertEqual(len(catalog.paths), 0)
+        self.assertEqual(len(catalog.uids), 0)
+        for index_id in catalog.indexes:
+            index = catalog.getIndex(index_id)
+            self.assertEqual(index.numObjects(), 0)
+
+    def test_getitem(self):
+        def extra(catalog):
+            catalog.addColumn('att1')
+
+        catalog = self._make_one(extra=extra)
+        catalog_rids = set(catalog.data)
+        brain_class = catalog._v_result_class
+        brains = []
+        brain_rids = set()
+        for rid in catalog_rids:
+            brain = catalog[rid]
+            brains.append(brain)
+            brain_rids.add(brain.getRID())
+            self.assertIsInstance(brain, brain_class)
+            self.assertEqual(brain.att1, 'att1')
+
+        self.assertEqual(len(brains), len(catalog))
+        self.assertEqual(catalog_rids, brain_rids)
+
     # updateBrains
-    # __getitem__
     # __setstate__
     # useBrains
     # getIndex

--- a/src/Products/ZCatalog/tests/test_zcatalog.py
+++ b/src/Products/ZCatalog/tests/test_zcatalog.py
@@ -265,6 +265,16 @@ class TestZCatalog(ZCatalogBase, unittest.TestCase):
 
     # getMetadataForRID
     # getIndexDataForRID
+
+    def testGetAllBrains(self):
+        brain_class = self._catalog._catalog._v_result_class
+        brains = []
+        for brain in self._catalog.getAllBrains():
+            brains.append(brain)
+            self.assertIsInstance(brain, brain_class)
+            self.assertTrue(hasattr(brain, 'title'))
+        self.assertEqual(len(brains), len(self._catalog))
+
     # schema
     # indexes
     # index_objects


### PR DESCRIPTION
The method returns a generator of brains for all cataloged objects. You can use this if you relied on `searchResults` returning all brains for empty queries before version 4.0a2.

Also add tests for the catalog's `__getitem__` and `clear` methods.

This is similar to the `catalog_get_all` method added to Plone's catalog_tool as part of plone/Products.CMFPlone@8520b2bc3ad6966e53673d92d164d06d05bf29e4.