### PR TITLE
Add precision property to date (range) indexes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 4.1 (unreleased)
 ----------------
 
+- Add new precision property to date and date range indexes.
+  This lets you index more coarse grained time values instead of the
+  default one minute based time resolution.
+
 - Add new `getAllBrains` method to the ZCatalog, returning a generator
   of brains for all cataloged objects. You can use this if you relied
   on `searchResults` returning all brains for empty queries before

--- a/src/Products/PluginIndexes/DateIndex/DateIndex.py
+++ b/src/Products/PluginIndexes/DateIndex/DateIndex.py
@@ -86,8 +86,12 @@ class DateIndex(UnIndex, PropertyManager):
     query_options = ('query', 'range', 'not')
 
     index_naive_time_as_local = True  # False means index as UTC
+    precision = 1  # precision of indexed time in minutes
     _properties = ({'id': 'index_naive_time_as_local',
                     'type': 'boolean',
+                    'mode': 'w'},
+                   {'id': 'precision',
+                    'type': 'int',
                     'mode': 'w'},)
 
     manage = manage_main = DTMLFile('dtml/manageDateIndex', globals())
@@ -179,6 +183,12 @@ class DateIndex(UnIndex, PropertyManager):
         mn = t_tup[4]
 
         t_val = ((((yr * 12 + mo) * 31 + dy) * 24 + hr) * 60 + mn)
+
+        # flatten to precision
+        if self.precision > 1:
+            t_val = t_val - (t_val % self.precision)
+
+        t_val = int(t_val)
 
         if t_val > MAX32:
             # t_val must be integer fitting in the 32bit range

--- a/src/Products/PluginIndexes/DateRangeIndex/dtml/addDateRangeIndex.dtml
+++ b/src/Products/PluginIndexes/DateRangeIndex/dtml/addDateRangeIndex.dtml
@@ -62,6 +62,16 @@ objects for those where a given date falls within the range.
    <input type="text" name="extra.ceiling_value:record" size="15" />
   </td>
  </tr>
+ <tr>
+  <td align="left" valign="top">
+  <div class="form-label">
+  Precision value (in minutes)
+  </div>
+  </td>
+  <td align="left" valign="top">
+   <input type="text" name="extra.precision_value:record" size="15" />
+  </td>
+ </tr>
   <tr>
     <td align="left" valign="top">
     </td>

--- a/src/Products/PluginIndexes/DateRangeIndex/dtml/manageDateRangeIndex.dtml
+++ b/src/Products/PluginIndexes/DateRangeIndex/dtml/manageDateRangeIndex.dtml
@@ -51,6 +51,15 @@ Distinct values: <dtml-var indexSize>
   </td>
 </tr>
 <tr>
+  <td align="left" valign="top">
+  <div class="form-label">
+  Precision value (in minutes)
+  </td>
+  <td align="left" valign="top">
+   <input name="precision_value" value="&dtml-getPrecisionValue;" />
+  </td>
+</tr>
+<tr>
   <td></td>
   <td align="left" valign="top">
   <div class="form-element">

--- a/src/Products/PluginIndexes/DateRangeIndex/tests.py
+++ b/src/Products/PluginIndexes/DateRangeIndex/tests.py
@@ -12,10 +12,13 @@
 ##############################################################################
 
 import unittest
-
+from datetime import datetime
+from DateTime.DateTime import DateTime
 from BTrees.IIBTree import IISet
 from OFS.SimpleItem import SimpleItem
 from Testing.makerequest import makerequest
+
+from Products.PluginIndexes.util import datetime_to_minutes
 
 
 class Dummy(object):
@@ -49,11 +52,14 @@ dummies = [(0, Dummy('a', None, None)),
            ]
 
 
-def matchingDummiesByTimeValue(value):
+def matchingDummiesByTimeValue(value, precision=1):
     result = []
+    value = datetime_to_minutes(value, precision)
     for i, dummy in dummies:
-        if ((dummy.start() is None or dummy.start() <= value) and
-                (dummy.stop() is None or dummy.stop() >= value)):
+        start = datetime_to_minutes(dummy.start(), precision)
+        stop = datetime_to_minutes(dummy.stop(), precision)
+        if ((start is None or start <= value) and
+                (stop is None or stop >= value)):
             result.append((i, dummy))
     return result
 
@@ -69,10 +75,11 @@ class DateRangeIndexTests(unittest.TestCase):
             import DateRangeIndex
         return DateRangeIndex
 
-    def _makeOne(self, id, since_field=None, until_field=None, caller=None,
-                 extra=None):
+    def _makeOne(self, id, since_field=None, until_field=None,
+                 caller=None, extra=None, precision_value=None):
         klass = self._getTargetClass()
-        index = klass(id, since_field, until_field, caller, extra)
+        index = klass(id, since_field, until_field, caller, extra,
+                      precision_value=precision_value)
 
         class DummyZCatalog(SimpleItem):
             id = 'DummyZCatalog'
@@ -94,10 +101,10 @@ class DateRangeIndexTests(unittest.TestCase):
                 result = result.keys()
             assert used == (index._since_field, index._until_field)
             assert len(result) == len(expectedValues), \
-                '%s | %s' % (list(result), expectedValues)
+                '%s: %s | %s' % (req, list(result), expectedValues)
             for k, v in expectedValues:
                 assert k in result
-            return result, used
+            return (result, used)
 
         cache = index.getRequestCache()
         cache.clear()
@@ -179,8 +186,6 @@ class DateRangeIndexTests(unittest.TestCase):
         self.assertTrue(1 in index._always.keys())
 
     def test_datetime(self):
-        from datetime import datetime
-        from DateTime.DateTime import DateTime
         from Products.PluginIndexes.DateIndex.tests import _getEastern
         before = datetime(2009, 7, 11, 0, 0, tzinfo=_getEastern())
         start = datetime(2009, 7, 13, 5, 15, tzinfo=_getEastern())
@@ -208,8 +213,6 @@ class DateRangeIndexTests(unittest.TestCase):
         self._checkApply(index, {'work': after}, [])
 
     def test_datetime_naive_timezone(self):
-        from datetime import datetime
-        from DateTime.DateTime import DateTime
         from Products.PluginIndexes.DateIndex.DateIndex import Local
         before = datetime(2009, 7, 11, 0, 0)
         start = datetime(2009, 7, 13, 5, 15)
@@ -297,3 +300,26 @@ class DateRangeIndexTests(unittest.TestCase):
         # clear is a change
         index.clear()
         self.assertEqual(index.getCounter(), 3)
+
+    def test_precision(self):
+        precision = 5
+        index = self._makeOne('work', 'start', 'stop',
+                              precision_value=precision)
+
+        for i, dummy in dummies:
+            index.index_object(i, dummy)
+
+        for i, dummy in dummies:
+            datum = map(lambda d: datetime_to_minutes(d, precision),
+                        dummy.datum())
+            self.assertEqual(index.getEntryForObject(i), tuple(datum))
+
+        for value in range(-1, 15):
+            matches = matchingDummiesByTimeValue(value, precision)
+            results, used = self._checkApply(index, {'work': value}, matches)
+            matches = sorted(matches, key=lambda d: d[1].name())
+            for result, match in zip(results, matches):
+                datum = map(lambda d: datetime_to_minutes(d, precision),
+                            match[1].datum())
+                self.assertEqual(index.getEntryForObject(result),
+                                 tuple(datum))

--- a/src/Products/PluginIndexes/util.py
+++ b/src/Products/PluginIndexes/util.py
@@ -11,7 +11,12 @@
 #
 ##############################################################################
 
+from datetime import datetime
+
+from DateTime.DateTime import DateTime
 import six
+
+MAX32 = int(2 ** 31 - 1)
 
 
 def safe_callable(ob):
@@ -20,3 +25,28 @@ def safe_callable(ob):
         return hasattr(ob, '__call__') or isinstance(ob, six.class_types)
     else:
         return callable(ob)
+
+
+def datetime_to_minutes(value, precision=1,
+                        max_value=MAX32, min_value=-MAX32):
+    if value is None:
+        return value
+
+    if isinstance(value, (str, datetime)):
+        value = DateTime(value)
+
+    if isinstance(value, DateTime):
+        value = value.millis() / 1000 / 60  # flatten to minutes
+
+    # flatten to precision
+    if precision > 1:
+        value = value - (value % precision)
+
+    value = int(value)
+
+    if value > max_value or value < min_value:
+        # value must be integer fitting in the range (default 32bit)
+        raise OverflowError(
+            '%s is not within the range of dates allowed.' % value)
+
+    return value


### PR DESCRIPTION
This is #18 rebased onto current master.

As the original PR said, this allows one to configure the indexes to be more coarse grained and potentially get better per-request cache utilization as a result.