### PR TITLE
Fix logging issue in KeywordIndex.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Changelog
   on `searchResults` returning all brains for empty queries before
   version 4.0a2.
 
+- Fix logging issue in KeywordIndex.
+
 4.0.1 (2017-10-10)
 ------------------
 

--- a/src/Products/PluginIndexes/KeywordIndex/KeywordIndex.py
+++ b/src/Products/PluginIndexes/KeywordIndex/KeywordIndex.py
@@ -138,7 +138,7 @@ class KeywordIndex(UnIndex):
             LOG.debug('%s: Attempt to unindex nonexistent '
                       'document with id %s' %
                       (self.__class__.__name__, documentId),
-                      error=sys.exc_info())
+                      exc_info=True)
 
     manage = manage_main = DTMLFile('dtml/manageKeywordIndex', globals())
     manage_main._setName('manage_main')


### PR DESCRIPTION
The `debug` method of a logger does not accept an `error` keyword, see
https://docs.python.org/3.6/library/logging.html#logging.Logger.debug
resp.
https://docs.python.org/2/library/logging.html#logging.Logger.debug

This issue did not get noticed because the with the default log level in tests
this log message is discarded.