### PR TITLE
Fix TypeError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 4.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix a TypeError on Python 3 when trying to lookup in an OOBTree
+  a value for a key that has an invalid type
 
 
 4.1 (2018-03-06)

--- a/src/Products/PluginIndexes/unindex.py
+++ b/src/Products/PluginIndexes/unindex.py
@@ -563,6 +563,15 @@ class UnIndex(SimpleItem):
                     s = index.get(k, None)
                 except TypeError:
                     # key is not valid for this Btree so the value is None
+                    LOG.error(
+                        '{context!s}: query_index tried '
+                        'to look up key {key!r} from index {index!r} '
+                        'but key was of the wrong type.'.format(
+                            context=self.__class__.__name__,
+                            key=k,
+                            index=self.id,
+                        )
+                    )
                     s = None
                 # If None, try to bail early
                 if s is None:

--- a/src/Products/PluginIndexes/unindex.py
+++ b/src/Products/PluginIndexes/unindex.py
@@ -559,7 +559,11 @@ class UnIndex(SimpleItem):
                     # other object. BTrees 4.0+ will throw a TypeError
                     # "object has default comparison".
                     continue
-                s = index.get(k, None)
+                try:
+                    s = index.get(k, None)
+                except TypeError:
+                    # key is not valid for this Btree so the value is None
+                    s = None
                 # If None, try to bail early
                 if s is None:
                     if operator == 'or':


### PR DESCRIPTION
This fixes an error when trying to get from an `OOBTree` a non existent value and the key has a type that cannot be compared with the existing keys