### PR TITLE
Handle WidCode bytes that were not decoded during conversion from Python 2 to Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 4.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Make sure WidCode decode handles bytes that were improperly
+  converted from Python 2 to Python 3.
 
 
 4.2 (2018-10-05)

--- a/src/Products/ZCTextIndex/WidCode.py
+++ b/src/Products/ZCTextIndex/WidCode.py
@@ -86,6 +86,9 @@ _prog = re.compile(r"[\x80-\xFF][\x00-\x7F]*")
 
 
 def decode(code):
+    # Handle bytes that were not properly decoded during Python 3 conversion
+    if not isinstance(code, str):
+        code = code.decode('latin1')
     # Decode a string into a list of wids.
     get = _decoding.get
     # Obscure:  while _decoding does have the key '\x80', its value is 0,


### PR DESCRIPTION
WidCode packs a list of integer ids into a native string. So far I haven't found a good way to make sure that string gets decoded appropriately (as latin-1) during conversion of a database from Python 2 to Python 3. The values are stored in a BTree on the ZCTextIndex so can't be targeted by zodbupdate decoder rules. I have a branch of zodbupdate that lets me specify a default encoding (utf-8) and store anything that couldn't be decoded with that encoding as bytes. This addition is meant to handle bytes that were put in place that way.