### PR TITLE
Import escape from html instead of cgi.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 4.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace deprecated ``cgi.escape`` with ``html.escape`` for Python 3.
 
 
 4.2 (2018-10-05)

--- a/src/Products/ZCTextIndex/ZCTextIndex.py
+++ b/src/Products/ZCTextIndex/ZCTextIndex.py
@@ -14,7 +14,7 @@
 """Plug in text index for ZCatalog with relevance ranking.
 """
 
-from cgi import escape
+from html import escape
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import manage_vocabulary

--- a/src/Products/ZCTextIndex/ZCTextIndex.py
+++ b/src/Products/ZCTextIndex/ZCTextIndex.py
@@ -14,7 +14,10 @@
 """Plug in text index for ZCatalog with relevance ranking.
 """
 
-from html import escape
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
 
 from AccessControl.class_init import InitializeClass
 from AccessControl.Permissions import manage_vocabulary

--- a/src/Products/ZCTextIndex/tests/testZCTextIndex.py
+++ b/src/Products/ZCTextIndex/tests/testZCTextIndex.py
@@ -273,6 +273,28 @@ class ZCIndexTestsBase(object):
                         'did not expect to find {0}'.format(w)
                     )
 
+    def testLexiconIsNotFoundRaisesLookupError(self):
+        caller = LexiconHolder(self.lexicon)
+        with self.assertRaises(LookupError):
+            ZCTextIndex(
+                'name',
+                extra=None,
+                caller=caller,
+            )
+
+    def testInvalidIndexTypeRaisesValueError(self):
+        caller = LexiconHolder(self.lexicon)
+        class Extra(object):
+            index_type = 'Some invalid index type'
+        with self.assertRaises(ValueError):
+            ZCTextIndex(
+                'name',
+                extra=Extra,
+                caller=caller,
+                index_factory=None,
+                lexicon_id='lexicon'
+            )
+
 
 class CosineIndexTests(ZCIndexTestsBase, testIndex.CosineIndexTest):
 


### PR DESCRIPTION
Both usages of escape are not covered by tests -> WIP -> gonna try to write some tests, though it will take some time, as I have no experience with the unit test framework, as I only use py.test at work.

Fixes #47.