### PR TITLE
Fix "invalid escape sequence" warning.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ----------------
 
 - Replace deprecated ``cgi.escape`` with ``html.escape`` for Python 3.
+- Fix "invalid escape sequence" warning in Python 3.
 
 
 4.2 (2018-10-05)

--- a/src/Products/ZCTextIndex/tests/testZCTextIndex.py
+++ b/src/Products/ZCTextIndex/tests/testZCTextIndex.py
@@ -239,7 +239,7 @@ class ZCIndexTestsBase(object):
         d = {}  # word -> list of version numbers containing that word
         for version, i in zip(text, range(N)):
             # use a simple splitter rather than an official one
-            words = [w for w in re.split('\W+', version.lower())
+            words = [w for w in re.split(r'\W+', version.lower())
                      if len(w) > 1 and w not in stop]
             word_seen = {}
             for w in words:


### PR DESCRIPTION
Beginning with Python 3.6 a DeprecationWarning is shown when an invalid
escape sequence is used. Converting the string into a raw string fixes
the problem.

cf
https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior