### PR TITLE
Backport getAllBrains to 2.13 branch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,11 @@ Changelog
 2.13.30 (unreleased)
 --------------------
 
-- Nothing changed yet.
-
+- Add new `getAllBrains` method to the ZCatalog, returning a generator
+  of brains for all cataloged objects. You can use this if you relied
+  on `searchResults` returning all brains for empty queries before
+  version 4.0a2. This is a backport of this method in version 4.1 to ease the
+  migration.
 
 2.13.29 (2017-10-13)
 --------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,6 @@
 [buildout]
 extends = http://download.zope.org/Zope2/index/2.13.21/versions.cfg
+index = https://pypi.org/simple
 
 develop = .
 parts = interpreter test test-globalrequest

--- a/src/Products/ZCatalog/ZCatalog.py
+++ b/src/Products/ZCatalog/ZCatalog.py
@@ -549,6 +549,12 @@ class ZCatalog(Folder, Persistent, Implicit):
         # return the current index contents for the specific rid
         return self._catalog.getIndexDataForRID(rid)
 
+    security.declareProtected(search_zcatalog, 'getAllBrains')
+    def getAllBrains(self):
+        # return a generator of brains for all cataloged objects
+        for rid in self._catalog.data:
+            yield self._catalog[rid]
+
     security.declareProtected(search_zcatalog, 'schema')
     def schema(self):
         return self._catalog.schema.keys()

--- a/src/Products/ZCatalog/tests/test_catalog.py
+++ b/src/Products/ZCatalog/tests/test_catalog.py
@@ -221,6 +221,28 @@ class TestCatalog(CatalogBase, unittest.TestCase):
             self._catalog.catalogObject(dummy(self.nums[x]), repr(x))
         self._catalog = self._catalog.__of__(dummy('foo'))
 
+    def _make_one(self, extra=None):
+        from Products.ZCatalog.Catalog import Catalog
+        catalog = Catalog()
+        catalog.lexicon = PLexicon('lexicon')
+
+        att1 = FieldIndex('att1')
+        catalog.addIndex('att1', att1)
+
+        att2 = ZCTextIndex('att2', caller=catalog,
+                           index_factory=OkapiIndex, lexicon_id='lexicon')
+        catalog.addIndex('att2', att2)
+
+        att3 = KeywordIndex('att3')
+        catalog.addIndex('att3', att3)
+
+        if extra is not None:
+            extra(catalog)
+
+        for x in range(0, self.upper):
+            catalog.catalogObject(dummy(self.nums[x]), repr(x))
+        return catalog.__of__(dummy('foo'))
+
     def test_clear(self):
         catalog = self._make_one()
         self.assertTrue(len(catalog) > 0)

--- a/src/Products/ZCatalog/tests/test_catalog.py
+++ b/src/Products/ZCatalog/tests/test_catalog.py
@@ -221,9 +221,39 @@ class TestCatalog(CatalogBase, unittest.TestCase):
             self._catalog.catalogObject(dummy(self.nums[x]), repr(x))
         self._catalog = self._catalog.__of__(dummy('foo'))
 
-    # clear
+    def test_clear(self):
+        catalog = self._make_one()
+        self.assertTrue(len(catalog) > 0)
+        catalog.clear()
+        self.assertEqual(catalog._length(), 0)
+        self.assertEqual(len(catalog), 0)
+        self.assertEqual(len(catalog.data), 0)
+        self.assertEqual(len(catalog.paths), 0)
+        self.assertEqual(len(catalog.uids), 0)
+        for index_id in catalog.indexes:
+            index = catalog.getIndex(index_id)
+            self.assertEqual(index.numObjects(), 0)
+
+    def test_getitem(self):
+        def extra(catalog):
+            catalog.addColumn('att1')
+
+        catalog = self._make_one(extra=extra)
+        catalog_rids = set(catalog.data)
+        brain_class = catalog._v_result_class
+        brains = []
+        brain_rids = set()
+        for rid in catalog_rids:
+            brain = catalog[rid]
+            brains.append(brain)
+            brain_rids.add(brain.getRID())
+            self.assertIsInstance(brain, brain_class)
+            self.assertEqual(brain.att1, 'att1')
+
+        self.assertEqual(len(brains), len(catalog))
+        self.assertEqual(catalog_rids, brain_rids)
+
     # updateBrains
-    # __getitem__
     # __setstate__
     # useBrains
     # getIndex

--- a/src/Products/ZCatalog/tests/test_zcatalog.py
+++ b/src/Products/ZCatalog/tests/test_zcatalog.py
@@ -260,6 +260,16 @@ class TestZCatalog(ZCatalogBase, unittest.TestCase):
 
     # getMetadataForRID
     # getIndexDataForRID
+
+    def testGetAllBrains(self):
+        brain_class = self._catalog._catalog._v_result_class
+        brains = []
+        for brain in self._catalog.getAllBrains():
+            brains.append(brain)
+            self.assertIsInstance(brain, brain_class)
+            self.assertTrue(hasattr(brain, 'title'))
+        self.assertEqual(len(brains), len(self._catalog))
+
     # schema
     # indexes
     # index_objects


### PR DESCRIPTION
Version 4.1 introduced `getAllBrains`.

This PR ports this feature to the 2.13 branch to ease the migration to version 4.x.