### PR TITLE
Query with invalid paramter should raise an error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 4.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Raise a ValueError if a query uses invalid index parameters. This prevents
+  the query from being changed without feedback to the user and delivering
+  implausible search results.
+  (`#67 <https://github.com/zopefoundation/Products.ZCatalog/pull/67>`_)
 
 
 4.4 (2019-03-08)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='Products.ZCatalog',
-    version='4.5.dev0',
+    version='5.0.dev0',
     url='https://github.com/zopefoundation/Products.ZCatalog',
     license='ZPL 2.1',
     description="Zope's indexing and search solution.",

--- a/src/Products/PluginIndexes/FieldIndex/tests.py
+++ b/src/Products/PluginIndexes/FieldIndex/tests.py
@@ -258,11 +258,11 @@ class FieldIndexTests(unittest.TestCase):
         # Make sure that range tests with incompatible paramters
         # raise a RuntimeError
         record['foo']['operator'] = 'and'
-        self.assertRaises(RuntimeError, self._checkApply, record, expect)
+        self.assertRaises(ValueError, self._checkApply, record, expect)
 
         # alternative syntax of record
         record = {'foo': [-99, 3],
                   'foo_range': 'min:max',
                   'foo_operator': 'and'}
 
-        self.assertRaises(RuntimeError, self._checkApply, record, expect)
+        self.assertRaises(ValueError, self._checkApply, record, expect)

--- a/src/Products/PluginIndexes/FieldIndex/tests.py
+++ b/src/Products/PluginIndexes/FieldIndex/tests.py
@@ -256,6 +256,13 @@ class FieldIndexTests(unittest.TestCase):
         self._checkApply(record, expect)
 
         # Make sure that range tests with incompatible paramters
-        # don't return empty sets.
+        # raise a RuntimeError
         record['foo']['operator'] = 'and'
-        self._checkApply(record, expect)
+        self.assertRaises(RuntimeError, self._checkApply, record, expect)
+
+        # alternative syntax of record
+        record = {'foo': [-99, 3],
+                  'foo_range': 'min:max',
+                  'foo_operator': 'and'}
+
+        self.assertRaises(RuntimeError, self._checkApply, record, expect)

--- a/src/Products/ZCatalog/query.py
+++ b/src/Products/ZCatalog/query.py
@@ -117,13 +117,15 @@ class IndexQuery(object):
                 if op == 'query':
                     continue
                 if op not in options:
-                    raise RuntimeError('index %s: option %r is not valid' % (iid, op)) 
+                    raise RuntimeError(('index {0!r}: option {1!r}'
+                                        ' is not valid').format(iid, op))
         else:
             for field in request.keys():
                 if field.startswith(iid + '_'):
                     iid_tmp, op = field.split('_')
                     if op not in options:
-                        raise RuntimeError('index %s: option %r is not valid' % (iid, op))
+                        raise RuntimeError(('index {0!r}: option {1!r}'
+                                            ' is not valid').format(iid, op))
         self._options = options
 
     @property
@@ -135,7 +137,8 @@ class IndexQuery(object):
         iid = self.id
         value = value.lower()
         if value not in self.operators:
-            raise RuntimeError('index %s: operator %r is not valid' % (iid, value))
+            raise RuntimeError(('index {0!r}: operator {1!r}'
+                                ' is not valid').format(iid, value))
         self._operator = value.lower()
 
     def get(self, key, default_v=None):

--- a/src/Products/ZCatalog/query.py
+++ b/src/Products/ZCatalog/query.py
@@ -56,6 +56,7 @@ class IndexQuery(object):
         self.id = iid
         self.operators = operators
         self.operator = default_operator
+        self.options = options
 
         if iid not in request:
             self.keys = None
@@ -76,11 +77,7 @@ class IndexQuery(object):
                 if op == 'query':
                     continue
 
-                if op in options:
-                    self.set(op, param[op])
-                else:
-                    raise ValueError(('index {0!r}: option {1!r}'
-                                      ' is not valid').format(iid, op))
+                self.set(op, param[op])
 
         else:
             # query is tuple, list, string, number, or something else
@@ -92,11 +89,8 @@ class IndexQuery(object):
             for field in request.keys():
                 if field.startswith(iid + '_'):
                     iid_tmp, op = field.split('_')
-                    if op in options:
-                        self.set(op, request[field])
-                    else:
-                        raise ValueError(('index {0!r}: option {1!r}'
-                                          ' is not valid').format(iid, op))
+
+                    self.set(op, request[field])
 
         self.keys = keys
         not_value = getattr(self, 'not', None)
@@ -125,4 +119,8 @@ class IndexQuery(object):
         return default_v
 
     def set(self, key, value):
-        setattr(self, key, value)
+        if key in self.options:
+            setattr(self, key, value)
+        else:
+            raise ValueError(('index {0!r}: option {1!r}'
+                              ' is not valid').format(self.id, key))

--- a/src/Products/ZCatalog/tests/test_query.py
+++ b/src/Products/ZCatalog/tests/test_query.py
@@ -66,3 +66,35 @@ class TestIndexQuery(unittest.TestCase):
         parser = self._makeOne(request, 'path', ('query', 'not'))
         self.assertEqual(parser.get('keys'), ['foo'])
         self.assertEqual(parser.get('not'), [0])
+
+    def test_operator_dict(self):
+        request = {'path': {'query': 'foo', 'operator': 'bar'}}
+        self.assertRaises(RuntimeError,
+                          self._makeOne,
+                          request,
+                          'path',
+                          ('query', 'operator'),
+                          ('or', 'and'))
+
+    def test_operator_string(self):
+        request = {'path': 'foo', 'path_operator': 'bar'}
+        self.assertRaises(RuntimeError,
+                          self._makeOne,
+                          request, 'path',
+                          ('query', 'operator'),
+                          ('or', 'and'))
+
+    def test_options_dict(self):
+        request = {'path': {'query': 'foo', 'baropt': 'dummy'}}
+        self.assertRaises(RuntimeError,
+                          self._makeOne,
+                          request,
+                          'path',
+                          ('query', 'operator'))
+
+    def test_options_string(self):
+        request = {'path': 'foo', 'path_baropt': 'dummy'}
+        self.assertRaises(RuntimeError,
+                          self._makeOne,
+                          request, 'path',
+                          ('query', 'operator'))

--- a/src/Products/ZCatalog/tests/test_query.py
+++ b/src/Products/ZCatalog/tests/test_query.py
@@ -69,7 +69,7 @@ class TestIndexQuery(unittest.TestCase):
 
     def test_operator_dict(self):
         request = {'path': {'query': 'foo', 'operator': 'bar'}}
-        self.assertRaises(RuntimeError,
+        self.assertRaises(ValueError,
                           self._makeOne,
                           request,
                           'path',
@@ -78,7 +78,7 @@ class TestIndexQuery(unittest.TestCase):
 
     def test_operator_string(self):
         request = {'path': 'foo', 'path_operator': 'bar'}
-        self.assertRaises(RuntimeError,
+        self.assertRaises(ValueError,
                           self._makeOne,
                           request, 'path',
                           ('query', 'operator'),
@@ -86,7 +86,7 @@ class TestIndexQuery(unittest.TestCase):
 
     def test_options_dict(self):
         request = {'path': {'query': 'foo', 'baropt': 'dummy'}}
-        self.assertRaises(RuntimeError,
+        self.assertRaises(ValueError,
                           self._makeOne,
                           request,
                           'path',
@@ -94,7 +94,7 @@ class TestIndexQuery(unittest.TestCase):
 
     def test_options_string(self):
         request = {'path': 'foo', 'path_baropt': 'dummy'}
-        self.assertRaises(RuntimeError,
+        self.assertRaises(ValueError,
                           self._makeOne,
                           request, 'path',
                           ('query', 'operator'))


### PR DESCRIPTION
Parameters can be used for a query that are not supported by the indexes. The user does not receive a feedback about the invalid used parameters. Results of a query could therefore misinterpreted. This behavior has already been identified https://github.com/zopefoundation/Products.ZCatalog/blob/dd30d4413eb1090f2a05bb4cfe438dc0a9690611/src/Products/PluginIndexes/FieldIndex/tests.py#L258-L259 but the strategy is simply to ignore the invalid parameter. I therefore suggest that instead of skipping invalid parameters, an error should be raised.