### PR TITLE
Skip performance test under windows.

### DIFF
--- a/src/Products/PluginIndexes/CompositeIndex/tests/testCompositeIndex.py
+++ b/src/Products/PluginIndexes/CompositeIndex/tests/testCompositeIndex.py
@@ -191,6 +191,10 @@ class CompositeIndexPerformanceTest(CompositeIndexTestMixin,
                                     unittest.TestCase):
     layer = PseudoLayer
 
+    @unittest.skipIf(
+        sys.platform.startswith('win'),
+        'Time() is not well resolved in Windows.'
+        ' In Python 3 use time.perf_count()')
     def testPerformance(self):
         self.enableLog()
 


### PR DESCRIPTION
`time()` does not produce high resolved estimates and results in zero duration.