### PR TITLE
sort-on multiple indexes is broken#81

### DIFF
--- a/src/Products/ZCatalog/Catalog.py
+++ b/src/Products/ZCatalog/Catalog.py
@@ -997,7 +997,7 @@ class Catalog(Persistent, Acquisition.Implicit, ExtensionClass.Base):
         # Choose one of the sort algorithms.
         if iterate_sort_index:
             sort_func = self._sort_iterate_index
-        elif limit is None or (limit * 4 > rlen):
+        elif limit is None or second_indexes or (limit * 4 > rlen):
             sort_func = self._sort_iterate_resultset
         elif first_reverse:
             sort_func = self._sort_nbest

--- a/src/Products/ZCatalog/Catalog.py
+++ b/src/Products/ZCatalog/Catalog.py
@@ -997,7 +997,7 @@ class Catalog(Persistent, Acquisition.Implicit, ExtensionClass.Base):
         # Choose one of the sort algorithms.
         if iterate_sort_index:
             sort_func = self._sort_iterate_index
-        elif limit is None or second_indexes or (limit * 4 > rlen):
+        elif limit is None or (limit * 4 > rlen):
             sort_func = self._sort_iterate_resultset
         elif first_reverse:
             sort_func = self._sort_nbest

--- a/src/Products/ZCatalog/Catalog.py
+++ b/src/Products/ZCatalog/Catalog.py
@@ -907,8 +907,11 @@ class Catalog(Persistent, Acquisition.Implicit, ExtensionClass.Base):
                     # This document is not in the sort key index, skip it.
                     actual_result_count -= 1
                 else:
-                    if n >= limit and key >= best:
-                        continue
+                    try:
+                        if n >= limit and key >= best:
+                            continue
+                    except:
+                        pass
                     i = bisect(keys, key)
                     keys.insert(i, key)
                     result.insert(i, (full_key, did, self.__getitem__))
@@ -997,7 +1000,7 @@ class Catalog(Persistent, Acquisition.Implicit, ExtensionClass.Base):
         # Choose one of the sort algorithms.
         if iterate_sort_index:
             sort_func = self._sort_iterate_index
-        elif limit is None or second_indexes or (limit * 4 > rlen):
+        elif limit is None or (limit * 4 > rlen):
             sort_func = self._sort_iterate_resultset
         elif first_reverse:
             sort_func = self._sort_nbest

--- a/src/Products/ZCatalog/tests/test_catalog.py
+++ b/src/Products/ZCatalog/tests/test_catalog.py
@@ -755,12 +755,20 @@ class TestCatalogSortBatch(unittest.TestCase):
         for x in range(self.upper):
             self.assertEqual(a[x].num, x)
 
-    def test_sort_on_two2(self):
+    def test_sort_on_two_limit_10(self):
         catalog = self._make_one(cls=Dummy2)
         upper = self.upper
         a = catalog(sort_on=('att1', 'num'), att1='att1',  b_start=0, b_size=10)
         self.assertEqual(len(a), 10)
         for x in range(10):
+            self.assertEqual(a[x].num, x)
+
+    def test_sort_on_two_limit_50(self):
+        catalog = self._make_one(cls=Dummy2)
+        upper = self.upper
+        a = catalog(sort_on=('att1', 'num'), att1='att1',  b_start=0, b_size=50)
+        self.assertEqual(len(a), 50)
+        for x in range(50):
             self.assertEqual(a[x].num, x)
 
     def test_sort_on_two_reverse(self):

--- a/src/Products/ZCatalog/tests/test_catalog.py
+++ b/src/Products/ZCatalog/tests/test_catalog.py
@@ -55,6 +55,31 @@ class Dummy(ExtensionClass.Base):
         return ['col3']
 
 
+class Dummy2(ExtensionClass.Base):
+
+    att1 = 'att1'
+    att2 = 'att2'
+    att3 = ['att3']
+    foo = 'foo'
+
+    def __init__(self, num):
+        self.num = num
+        if isinstance(num, int) and (self.num % 10) == 0:
+            self.ends_in_zero = True
+        if isinstance(num, int) and self.num >= 50 :
+            self.att1 = 'other'
+
+    def col1(self):
+        return 'col1'
+
+    def col2(self):
+        return 'col2'
+
+    def col3(self):
+        return ['col3']
+
+
+
 class MultiFieldIndex(FieldIndex):
 
     def getIndexQueryNames(self):
@@ -210,7 +235,7 @@ class TestCatalog(unittest.TestCase):
         nums[i] = nums[j]
         nums[j] = tmp
 
-    def _make_one(self, extra=None):
+    def _make_one(self, extra=None, cls=Dummy):
         from Products.ZCatalog.Catalog import Catalog
         catalog = Catalog()
         catalog.lexicon = PLexicon('lexicon')
@@ -229,8 +254,8 @@ class TestCatalog(unittest.TestCase):
             extra(catalog)
 
         for x in range(0, self.upper):
-            catalog.catalogObject(Dummy(self.nums[x]), repr(x))
-        return catalog.__of__(Dummy('foo'))
+            catalog.catalogObject(cls(self.nums[x]), repr(x))
+        return catalog.__of__(cls('foo'))
 
     def test_clear(self):
         catalog = self._make_one()
@@ -400,7 +425,7 @@ class TestCatalogSortBatch(unittest.TestCase):
         nums[i] = nums[j]
         nums[j] = tmp
 
-    def _make_one(self, extra=None):
+    def _make_one(self, extra=None, cls=Dummy):
         from Products.ZCatalog.Catalog import Catalog
         catalog = Catalog()
         catalog.lexicon = PLexicon('lexicon')
@@ -421,8 +446,8 @@ class TestCatalogSortBatch(unittest.TestCase):
             extra(catalog)
 
         for x in range(0, self.upper):
-            catalog.catalogObject(Dummy(self.nums[x]), repr(x))
-        return catalog.__of__(Dummy('foo'))
+            catalog.catalogObject(cls(self.nums[x]), repr(x))
+        return catalog.__of__(cls('foo'))
 
     def test_sorted_search_indexes_empty(self):
         catalog = self._make_one()
@@ -728,6 +753,14 @@ class TestCatalogSortBatch(unittest.TestCase):
         a = catalog(sort_on=('att1', 'num'), att1='att1')
         self.assertEqual(len(a), upper)
         for x in range(self.upper):
+            self.assertEqual(a[x].num, x)
+
+    def test_sort_on_two2(self):
+        catalog = self._make_one(cls=Dummy2)
+        upper = self.upper
+        a = catalog(sort_on=('att1', 'num'), att1='att1',  b_start=0, b_size=10)
+        self.assertEqual(len(a), 10)
+        for x in range(10):
             self.assertEqual(a[x].num, x)
 
     def test_sort_on_two_reverse(self):


### PR DESCRIPTION
This pullrequests adds a better testing for the multicolumn sort testcases.

The expected output is 16 errors:
[bettertests.log](https://github.com/zopefoundation/Products.ZCatalog/files/3537324/bettertests.log)

If line 1000 of catalog.py:
```
        # Choose one of the sort algorithms.
        if iterate_sort_index:
            sort_func = self._sort_iterate_index
        elif limit is None or (limit * 4 > rlen):
            sort_func = self._sort_iterate_resultset
        elif first_reverse:
            sort_func = self._sort_nbest
        else:
            sort_func = self._sort_nbest_reverse
```
is patched to 
```
        # Choose one of the sort algorithms.
        if iterate_sort_index:
            sort_func = self._sort_iterate_index
        elif limit is None or second_indexes or (limit * 4 > rlen):
            sort_func = self._sort_iterate_resultset
        elif first_reverse:
            sort_func = self._sort_nbest
        else:
            sort_func = self._sort_nbest_reverse
```
all tests are working. This patch ensures that in any case with multiple indexes self._sort_iterate_resultset is used. Ergo the errors are located in  self._sort_nbest, self._sort_nbest_reverse, only.

Please confirm that the new tests are OK. Then they may act as a new baseline for finding and fixing the bug in  self._sort_nbest, self._sort_nbest_reverse.

Cheers,
Volker