### PR TITLE
Extract logic from template.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix exception when viewing `Indexes` tab when Chameleon template
+  engine is deactivated.
+  (`#84 <https://github.com/zopefoundation/Products.ZCatalog/issues/84>`_)
 
 
 5.0.2 (2019-12-06)

--- a/src/Products/ZCatalog/ZCatalog.py
+++ b/src/Products/ZCatalog/ZCatalog.py
@@ -863,6 +863,17 @@ class ZCatalog(Folder, Persistent, Implicit):
         self._catalog.addIndex(name, index)
 
     @security.protected(manage_zcatalog_indexes)
+    def availableIndexes(self):
+        """Return a sorted list of indexes.
+
+        Only indexes get returned for which the user has adequate
+        permission to add them.
+        """
+        return sorted(
+            self.Indexes.filtered_meta_types(),
+            key=lambda meta_types: meta_types['name'])
+
+    @security.protected(manage_zcatalog_indexes)
     def delIndex(self, name):
         self._catalog.delIndex(name)
 

--- a/src/Products/ZCatalog/zpt/catalogIndexes.zpt
+++ b/src/Products/ZCatalog/zpt/catalogIndexes.zpt
@@ -12,7 +12,7 @@
 		added index. You may want to update the whole Catalog.
 	</p>
 	<tal:indexes define="indexes context/Indexes">
-		<tal:add define="filtered_meta_types python:sorted(indexes.filtered_meta_types(), key=lambda mt: mt['name'])">
+		<tal:add define="filtered_meta_types context/availableIndexes">
 			<form tal:attributes="action context/absolute_url" method="get">
 				<div class="form-group mt-4 mb-4">
 					<div class="input-group">


### PR DESCRIPTION
Instead of looking up available indexes in the template and sorting
them, now there is a method in ZCatalog.

This fixes #84

P.S.: As this is a pure refactoring of the structure, no behavior was changed, and also the extracted method is already well covered by an existing test (`Products/ZCatalog/tests/test_manage_indexes.py => test_sortby()`), no new test was written.

modified:   src/Products/ZCatalog/ZCatalog.py
modified:   src/Products/ZCatalog/zpt/catalogIndexes.zpt
