### PR TITLE
Do not break when indexing multiple indexes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix exception happaning when reindexing multiple indexes while having a
+  progress handler.
+  (`#89 <https://github.com/zopefoundation/Products.ZCatalog/pull/89>`_)
 
 
 5.0.1 (2019-06-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 5.1 (unreleased)
 ----------------
 
-- Fix exception happaning when reindexing multiple indexes while having a
+- Fix exception happening when reindexing multiple indexes while having a
   progress handler.
   (`#89 <https://github.com/zopefoundation/Products.ZCatalog/pull/89>`_)
 

--- a/src/Products/ZCatalog/ZCatalog.py
+++ b/src/Products/ZCatalog/ZCatalog.py
@@ -411,13 +411,15 @@ class ZCatalog(Folder, Persistent, Implicit):
     @security.protected(manage_zcatalog_entries)
     def reindexIndex(self, name, REQUEST, pghandler=None):
         if isinstance(name, str):
-            name = (name, )
+            idxs = (name, )
+         else:
+            idxs = name
 
         paths = self._catalog.uids.keys()
 
         i = 0
         if pghandler:
-            pghandler.init('reindexing %s' % name, len(paths))
+            pghandler.init('reindexing {}'.format(idxs), len(paths))
 
         for p in paths:
             i += 1
@@ -433,7 +435,7 @@ class ZCatalog(Folder, Persistent, Implicit):
             else:
                 # don't update metadata when only reindexing a single
                 # index via the UI
-                self.catalog_object(obj, p, idxs=name,
+                self.catalog_object(obj, p, idxs=idxs,
                                     update_metadata=0, pghandler=pghandler)
 
         if pghandler:

--- a/src/Products/ZCatalog/ZCatalog.py
+++ b/src/Products/ZCatalog/ZCatalog.py
@@ -410,11 +410,7 @@ class ZCatalog(Folder, Persistent, Implicit):
 
     @security.protected(manage_zcatalog_entries)
     def reindexIndex(self, name, REQUEST, pghandler=None):
-        if isinstance(name, str):
-            idxs = (name, )
-         else:
-            idxs = name
-
+        idxs = (name, ) if isinstance(name, str) else name
         paths = self._catalog.uids.keys()
 
         i = 0

--- a/src/Products/ZCatalog/ZCatalog.py
+++ b/src/Products/ZCatalog/ZCatalog.py
@@ -410,6 +410,8 @@ class ZCatalog(Folder, Persistent, Implicit):
 
     @security.protected(manage_zcatalog_entries)
     def reindexIndex(self, name, REQUEST, pghandler=None):
+        # This method does the actual reindexing of indexes.
+        # `name` can be the name of an index of a list of names.
         idxs = (name, ) if isinstance(name, str) else name
         paths = self._catalog.uids.keys()
 


### PR DESCRIPTION
When trying to reindex multiple indexes while having a progress handler it was breaking before with:

```
...
  File ".../Products.ZCatalog-5.0.1-py3.7.egg/Products/ZCatalog/ZCatalog.py", line 420, in reindexIndex
    pghandler.init('reindexing %s' % name, len(paths))
TypeError: not all arguments converted during string formatting
```