### PR TITLE
Rework request caching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Changelog
 5.1 (unreleased)
 ----------------
 
+- rework request caching to avoid stale cache results in scripts (with
+  an artificial request).
+  For details:
+  `#94 <https://github.com/zopefoundation/Products.ZCatalog/issues/94>`_,
+  `Plone 5.2 mass migration: bad search results
+  <https://community.plone.org/t/potential-memory-corruption-during-migration-plone-4-2-5-2/11655/11>`_
+
+
 
 5.0.4 (2020-02-11)
 ------------------

--- a/src/Products/PluginIndexes/unindex.py
+++ b/src/Products/PluginIndexes/unindex.py
@@ -13,8 +13,10 @@
 
 from logging import getLogger
 import sys
+from weakref import WeakKeyDictionary
 
 from Acquisition import (
+    aq_base,
     aq_inner,
     aq_parent,
     aq_get,
@@ -364,14 +366,22 @@ class UnIndex(SimpleItem):
         cache = None
         REQUEST = aq_get(self, 'REQUEST', None)
         if REQUEST is not None:
-            catalog = aq_parent(aq_parent(aq_inner(self)))
+            cache_container = REQUEST.get("__catalog_cache__")
+            if cache_container is None:
+                # we use a `WeakKeyDictionary` (rather than the
+                #   request directly) to avoid the type of problem
+                #   described in
+                #   "https://community.plone.org/t/potential-memory-corruption-during-migration-plone-4-2-5-2/11655/11"
+                cache_container = REQUEST["__catalog_cache__"] \
+                                  = WeakKeyDictionary()
+            # we use the parent (of type `Products.ZCatalog.Catalog.Catalog`)
+            #  as key to facilitate invalidation via its method
+            #  in the future
+            catalog = aq_base(aq_parent(aq_inner(self)))
             if catalog is not None:
-                # unique catalog identifier
-                key = '_catalogcache_{0}_{1}'.format(
-                    catalog.getId(), id(catalog))
-                cache = REQUEST.get(key, None)
+                cache = cache_container.get(catalog, None)
                 if cache is None:
-                    cache = REQUEST[key] = RequestCache()
+                    cache = cache_container[catalog] = RequestCache()
 
         return cache
 

--- a/src/Products/PluginIndexes/unindex.py
+++ b/src/Products/PluginIndexes/unindex.py
@@ -373,7 +373,7 @@ class UnIndex(SimpleItem):
                 #   described in
                 #   "https://community.plone.org/t/potential-memory-corruption-during-migration-plone-4-2-5-2/11655/11"
                 cache_container = REQUEST["__catalog_cache__"] \
-                                  = WeakKeyDictionary()
+                    = WeakKeyDictionary()
             # we use the parent (of type `Products.ZCatalog.Catalog.Catalog`)
             #  as key to facilitate invalidation via its method
             #  in the future

--- a/src/Products/PluginIndexes/unindex.py
+++ b/src/Products/PluginIndexes/unindex.py
@@ -365,7 +365,7 @@ class UnIndex(SimpleItem):
 
         cache = None
         REQUEST = aq_get(self, 'REQUEST', None)
-        if REQUEST is not None:
+        if hasattr(REQUEST, "get"):
             cache_container = REQUEST.get("__catalog_cache__")
             if cache_container is None:
                 # we use a `WeakKeyDictionary` (rather than the


### PR DESCRIPTION
This addresses #94 and "https://community.plone.org/t/potential-memory-corruption-during-migration-plone-4-2-5-2/11655/11".

Scripts developed for Plone are usually run with `bin/client1 run` which creates an artificial request. Such a script (performing a (mass) migration Plone 4.2 -> Plone 5.2 for many Plone portals) revealed that the cache keys used for the catalog's request caching are not sufficiently safe -- at least in a setup with an artificial request working on several catalogs in separate transactions.
This PR does not store the request caches directly in the request but instead uses an intermediate `WeakKeyDictionary` keyed directly with the catalog objects (rather than with a key derived from the catalog's id and address). This ensures that if the catalog object is released (no longer in memory; making its address ambiguous), the associated cached data is discarded.