### PR TITLE
update `catalogView.dtml` to changed behavior for "empty searches"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 ----------------
 
 - Update `catalogView.dtml` to changed behavior of empty searches
-  (`#101 <https://github.com/zopefoundation/Products.ZCatalog/issues/101>`_).
+  (`#102 <https://github.com/zopefoundation/Products.ZCatalog/issues/102>`_).
 
 - Fix case where index value is changed to None after previously being indexed.
   (`#100 <https://github.com/zopefoundation/Products.ZCatalog/issues/100>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 5.2 (unreleased)
 ----------------
 
+- Update `catalogView.dtml` to changed behavior of empty searches
+  (`#101 <https://github.com/zopefoundation/Products.ZCatalog/issues/101>`_).
+
 - Fix case where index value is changed to None after previously being indexed.
   (`#100 <https://github.com/zopefoundation/Products.ZCatalog/issues/100>`_)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 5.2 (unreleased)
 ----------------
 
+- Add new method ``searchAll`` to perform a search for all documents.
+
+- Document ``getAllBrains`` and ``searchAll`` in the interface.
+
 - Update `catalogView.dtml` to changed behavior of empty searches
   (`#102 <https://github.com/zopefoundation/Products.ZCatalog/issues/102>`_).
 

--- a/src/Products/ZCatalog/ZCatalog.py
+++ b/src/Products/ZCatalog/ZCatalog.py
@@ -44,6 +44,7 @@ import transaction
 from zExceptions import BadRequest
 from ZODB.POSException import ConflictError
 from zope.interface import implementer
+from ZTUtils.Lazy import LazyMap
 
 from Products.ZCatalog.Catalog import Catalog, CatalogError
 from Products.ZCatalog.interfaces import IZCatalog
@@ -565,6 +566,13 @@ class ZCatalog(Folder, Persistent, Implicit):
         # return a generator of brains for all cataloged objects
         for rid in self._catalog.data:
             yield self._catalog[rid]
+
+    @security.protected(search_zcatalog)
+    def searchAll(self):
+        # the result of a search for all documents
+        return LazyMap(self._catalog.__getitem__,
+                       self._catalog.data.keys(),
+                       len(self))
 
     @security.protected(search_zcatalog)
     def schema(self):

--- a/src/Products/ZCatalog/dtml/catalogView.dtml
+++ b/src/Products/ZCatalog/dtml/catalogView.dtml
@@ -4,7 +4,7 @@
 <main class="container-fluid">
 
     <dtml-let filterpath="REQUEST.get('filterpath', '')"
-              results="searchResults(path=filterpath) if filterpath else list(getAllBrains())">
+              results="searchResults(path=filterpath) if filterpath else searchAll()">
 <dtml-if results>
 
 <h1 class="form-label section-bar">Path filter</h1>

--- a/src/Products/ZCatalog/dtml/catalogView.dtml
+++ b/src/Products/ZCatalog/dtml/catalogView.dtml
@@ -3,8 +3,8 @@
 
 <main class="container-fluid">
 
-    <dtml-let filterpath="REQUEST.get('filterpath', '/')"
-              results="searchResults(path=filterpath)">
+    <dtml-let filterpath="REQUEST.get('filterpath', '')"
+              results="searchResults(path=filterpath) if filterpath else list(getAllBrains())">
 <dtml-if results>
 
 <h1 class="form-label section-bar">Path filter</h1>

--- a/src/Products/ZCatalog/interfaces.py
+++ b/src/Products/ZCatalog/interfaces.py
@@ -222,6 +222,12 @@ class IZCatalog(Interface):
         queries (even across catalogs) and merge and sort the combined results.
         """
 
+    def searchAll():
+        """the result of a search for all documents as a sequence."""
+
+    def getAllBrains():
+        """the result of a search for all documents as an iterator."""
+
     def refreshCatalog(clear=0, pghandler=None):
         """Reindex every object we can find, removing the unreachable
         ones from the index.

--- a/src/Products/ZCatalog/tests/test_zcatalog.py
+++ b/src/Products/ZCatalog/tests/test_zcatalog.py
@@ -19,6 +19,7 @@ from AccessControl import Unauthorized
 from Acquisition import Implicit
 import ExtensionClass
 from OFS.Folder import Folder as OFS_Folder
+from Testing.makerequest import makerequest
 
 
 class Folder(OFS_Folder):
@@ -306,6 +307,14 @@ class TestZCatalog(ZCatalogBase, unittest.TestCase):
     # resolve_path
     # manage_setProgress
     # _getProgressThreshold
+
+    def test_catalogView(self):
+        catalog = makerequest(self._catalog)
+        # hack `getPhysicalPath` to avoid problem with the catalog plan
+        catalog.getPhysicalPath = None
+        vr = catalog.manage_catalogView()
+        self.assertTrue("There are no objects in the Catalog." not in vr,
+                        "catalogView wrongly reports `no objects`")
 
 
 class TestAddDelColumnIndex(ZCatalogBase, unittest.TestCase):

--- a/src/Products/ZCatalog/tests/test_zcatalog.py
+++ b/src/Products/ZCatalog/tests/test_zcatalog.py
@@ -276,6 +276,12 @@ class TestZCatalog(ZCatalogBase, unittest.TestCase):
             self.assertTrue(hasattr(brain, 'title'))
         self.assertEqual(len(brains), len(self._catalog))
 
+    def testSearchAll(self):
+        all = self._catalog.searchAll()
+        for b in all:
+            self.assertTrue(hasattr(b, 'title'))
+        self.assertEqual(len(all), len(self._catalog))
+
     # schema
     # indexes
     # index_objects
@@ -312,6 +318,8 @@ class TestZCatalog(ZCatalogBase, unittest.TestCase):
         catalog = makerequest(self._catalog)
         # hack `getPhysicalPath` to avoid problem with the catalog plan
         catalog.getPhysicalPath = None
+        # provide `ZopeVersion`
+        catalog.ZopeVersion = lambda *arg, **kw: 4
         vr = catalog.manage_catalogView()
         self.assertTrue("There are no objects in the Catalog." not in vr,
                         "catalogView wrongly reports `no objects`")


### PR DESCRIPTION
This fixes #102 (and #101).

It also interprets a missing or empty `filterpath` as "no restriction" (instead of `"/"`). This allows a potentially available `path` index to index generalized paths (not necessary starting with `"/"`).