### PR TITLE
Fix reversed sorting by multiple index + limit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Fix case where multiple indexes with similar name seperated by ``_`` were interpreted as options.
   (`#78 <https://github.com/zopefoundation/Products.ZCatalog/issues/78>`_)
+- Fix reversed sorting by multiple index by forcing the ``_sort_iterate_resultset``
+  sorting method when we have more than one sorting index
+  (`#108 <https://github.com/zopefoundation/Products.ZCatalog/issues/108>`_)
 
 
 6.0 (2020-10-08)

--- a/src/Products/ZCatalog/Catalog.py
+++ b/src/Products/ZCatalog/Catalog.py
@@ -1000,7 +1000,7 @@ class Catalog(Persistent, Acquisition.Implicit, ExtensionClass.Base):
         # Choose one of the sort algorithms.
         if iterate_sort_index:
             sort_func = self._sort_iterate_index
-        elif limit is None or (limit * 4 > rlen):
+        elif limit is None or (limit * 4 > rlen) or sort_index_length > 1:
             sort_func = self._sort_iterate_resultset
         elif first_reverse:
             sort_func = self._sort_nbest

--- a/src/Products/ZCatalog/tests/test_catalog.py
+++ b/src/Products/ZCatalog/tests/test_catalog.py
@@ -739,6 +739,28 @@ class TestCatalogSortBatch(unittest.TestCase):
         for x in range(upper - 1):
             self.assertTrue(a[x].num > a[x + 1].num)
 
+    def test_sort_on_two_reverse_with_limit(self):
+        catalog = self._make_one()
+        for num in range(-10, 0):
+            obj = Dummy(num)
+            obj.att1 = "att1foo"
+            obj.att2 = "att2"
+            catalog.catalogObject(obj, repr(num))
+        a = catalog(
+            att2='att2',
+            sort_on=('att1', 'num'),
+            sort_order='reverse',
+            sort_limit=20,
+        )
+        self.assertEqual(
+            [x.num for x in a[:10]],
+            [-1, -2, -3, -4, -5, -6, -7, -8, -9, -10],
+        )
+        self.assertEqual(
+            [x.num for x in a[10:]],
+            [99, 98, 97, 96, 95, 94, 93, 92, 91, 90],
+        )
+
     def test_sort_on_two_reverse_neither(self):
         catalog = self._make_one()
         upper = self.upper


### PR DESCRIPTION
Fix reversed sorting by multiple index by forcing the ``_sort_iterate_resultset`` sorting method when we have more than one sorting index

Fixes #108