### PR TITLE
fix typo

### DIFF
--- a/src/Products/ZCatalog/interfaces.py
+++ b/src/Products/ZCatalog/interfaces.py
@@ -289,7 +289,7 @@ class ICatalogBrain(Interface):
 
 
 class IProgressHandler(Interface):
-    """ A handler to log progress informations for long running
+    """ A handler to log progress information for long running
         operations.
     """
 


### PR DESCRIPTION
cf https://english.stackexchange.com/questions/117552/why-does-information-not-have-a-plural-form