### PR TITLE
Optimize plain "not" queries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 6.1 (unreleased)
 ----------------
-
+- Improve performance of simple ``not`` queries on large catalogs.
 - Fix case where multiple indexes with similar name seperated by ``_`` were interpreted as options.
   (`#78 <https://github.com/zopefoundation/Products.ZCatalog/issues/78>`_)
 - Fix reversed sorting by multiple index by forcing the ``_sort_iterate_resultset``

--- a/src/Products/PluginIndexes/CompositeIndex/tests/testCompositeIndex.py
+++ b/src/Products/PluginIndexes/CompositeIndex/tests/testCompositeIndex.py
@@ -285,7 +285,7 @@ class CompositeIndexPerformanceTest(CompositeIndexTestMixin,
                 # search must be roughly faster than default search
                 if res1 and res2:
                     self.assertLess(
-                        0.5 * duration2,
+                        0.4 * duration2,
                         duration1,
                         (duration2, duration1, query))
 

--- a/src/Products/PluginIndexes/unindex.py
+++ b/src/Products/PluginIndexes/unindex.py
@@ -504,7 +504,12 @@ class UnIndex(SimpleItem):
                 i_not_parm = self._apply_not(not_parm, resultset)
                 if i_not_parm:
                     return difference(resultset, i_not_parm)
-            record.keys = [k for k in index.keys() if k not in not_parm]
+            record.keys = list(index)
+            for parm in not_parm:
+                try:
+                    record.keys.remove(parm)
+                except ValueError:
+                    pass
         else:
             # convert query arguments into indexed format
             record.keys = list(map(self._convert, record.keys))

--- a/src/Products/PluginIndexes/unindex.py
+++ b/src/Products/PluginIndexes/unindex.py
@@ -479,15 +479,6 @@ class UnIndex(SimpleItem):
 
                     return cached
 
-        if not record.keys and not_parm:
-            # convert into indexed format
-            not_parm = list(map(self._convert, not_parm))
-            # we have only a 'not' query
-            record.keys = [k for k in index.keys() if k not in not_parm]
-        else:
-            # convert query arguments into indexed format
-            record.keys = list(map(self._convert, record.keys))
-
         # Range parameter
         range_parm = record.get('range', None)
         if range_parm:
@@ -502,6 +493,21 @@ class UnIndex(SimpleItem):
             # see if any usage params are sent to field
             opr = record.usage.lower().split(':')
             opr, opr_args = opr[0], opr[1:]
+
+        # not query
+        if not record.keys and not_parm:
+            # convert into indexed format
+            not_parm = list(map(self._convert, not_parm))
+            # we have only a 'not' query
+            # shortcut/optimization if we have no 'opr' (i.e. no range)
+            if resultset is not None and opr is None:
+                i_not_parm = self._apply_not(not_parm, resultset)
+                if i_not_parm:
+                    return difference(resultset, i_not_parm)
+            record.keys = [k for k in index.keys() if k not in not_parm]
+        else:
+            # convert query arguments into indexed format
+            record.keys = list(map(self._convert, record.keys))
 
         if opr == 'range':  # range search
             if 'min' in opr_args:


### PR DESCRIPTION
In Plone 6 we do queries returning a result except one item (the current context). A `not` query on the UID catalog is used to do this. In larger projects with several 10 or 100 thousands object cataloged, this slowed down queries to take several seconds. Without the `not` everything was fast.

After some profiling we found the time is wasted in this loop https://github.com/zopefoundation/Products.ZCatalog/blob/7f614a6394e236beae6ba69053bfb8c04d3f073a/src/Products/PluginIndexes/unindex.py#L575-L664 primary while factoring IISets here https://github.com/zopefoundation/Products.ZCatalog/blob/master/src/Products/PluginIndexes/unindex.py#L608

Whats happens?
The `not` query is written to return all values except the ones matching. Thus, for a single UID, this creates an result containing all index keys, except one. This is very expensive.

What I have done:
If the code detects a simple `not` query (without any operators) excluding only one or more keys, I shortcut the whole `index_query` and return the previous result w/o the current catalog id.

Does it help?
Yes. We bench-marked our query on a customer database with ~367000 catalogued objects. It cut down the whole requests time from ~1200ms to ~80ms (with 40ms of it been not query time in both).

cc @tisto @mauritsvanrees @cekk 