### PR TITLE
Further optimize excluding results in not queries

### DIFF
--- a/src/Products/PluginIndexes/CompositeIndex/tests/testCompositeIndex.py
+++ b/src/Products/PluginIndexes/CompositeIndex/tests/testCompositeIndex.py
@@ -285,7 +285,7 @@ class CompositeIndexPerformanceTest(CompositeIndexTestMixin,
                 # search must be roughly faster than default search
                 if res1 and res2:
                     self.assertLess(
-                        0.5 * duration2,
+                        0.4 * duration2,
                         duration1,
                         (duration2, duration1, query))
 

--- a/src/Products/PluginIndexes/unindex.py
+++ b/src/Products/PluginIndexes/unindex.py
@@ -504,7 +504,12 @@ class UnIndex(SimpleItem):
                 i_not_parm = self._apply_not(not_parm, resultset)
                 if i_not_parm:
                     return difference(resultset, i_not_parm)
-            record.keys = [k for k in index.keys() if k not in not_parm]
+            record.keys = list(index)
+            for parm in not_parm:
+                try:
+                    record.keys.remove(parm)
+                except ValueError:
+                    pass
         else:
             # convert query arguments into indexed format
             record.keys = list(map(self._convert, record.keys))


### PR DESCRIPTION
Usually the number of the parameters that have to be excluded in the not query is much lower than the number of values in the index, so it makes sense to actually try to pop them out from the list