### PR TITLE
Refactored ZMI templates for Zope4+

### DIFF
--- a/src/Products/ZCatalog/dtml/catalogObjectInformation.dtml
+++ b/src/Products/ZCatalog/dtml/catalogObjectInformation.dtml
@@ -1,103 +1,67 @@
-<dtml-var manage_page_header>
+<h3 class="mt-2">
+	Catalog record at 
+	<code>
+		<dtml-var expr="getpath(_.int(rid))" html_quote>
+	</code>
+</h3>
+<p>
+	The goal of this page is to provide basic debugging information
+	about what is in the Catalog on a specific object. Listed below is
+	all the information that the Catalog currently contains for the
+	above specified object. This information should match what is
+	currently in the instance of that object.
+</p>
 
-<main class="container-fluid">
-
-<table width="100%" borders="0" cellspacing="2" cellpadding="0">
-<tr bgcolor="#000000">
-  <td colspan="2">&nbsp;</td>
-</tr>
-<tr>
-  <td colspan="2">&nbsp;</td>
-</tr>
-<tr class="location-bar">
-  <td colspan="2" align="left">
-  <div class="std-text">
-  <h2>Catalog record at <dtml-var expr="getpath(_.int(rid))" html_quote></h2>
-  </div>
-  </td>
-</tr>
-<tr>
-  <td colspan="2" align="left">
-  <p class="form-help">
-  The goal of this page is to provide basic debugging information
-  about what is in the Catalog on a specific object.  Listed below is
-  all the information that the Catalog currently contains for the
-  above specified object.  This information should match what is
-  currently in the instance of that object.
-  </td>
-</tr>
-</table>
-<hr />
-<table width="100%" borders="0" cellspacing="2" cellpadding="0">
-<tr class="section-bar">
-  <td colspan="3" align="left">
-  <div class="form-label"><h3>Metadata Contents</h3></div>
-  </td>
-</tr>
-<tr>
-  <td colspan="3" align="left">
-  <p class="form-help">Metadata is the information that the Catalog
-  keeps inside of its internal structure so that it can answer
-  questions quickly.  This is then returned in the "brain" that the
-  Catalog gives back during searches.</p><br />
-  </td>
-</tr>
-<dtml-in expr="getMetadataForRID(_.int(rid)).items()">
-<dtml-if name="sequence-start">
-<tr class="list-header">
-  <td align="left" width="5%" bgcolor="#ffffff">&nbsp;</td>
-  <td align="left" width="25%" valign="top" class="list-item">Key</td>
-  <td align="left" width="70%" valign="top" class="list-item">Value</td>
-</dtml-if>
-<dtml-if name="sequence-odd"><tr class="row-hilite">
-<dtml-else><tr></dtml-if>
-  <td width="32" bgcolor="#ffffff">&nbsp;</td>
-  <td align="left" valign="top" class="form-element">
-    &dtml-sequence-key;
-  </td>
-  <Td align="left" valign="top" class="form-element">
-    &dtml-sequence-item;
-  </td>
-</tr>
-</dtml-in>
-</table>
-<hr />
-
-
-<table width="100%" borders="0" cellspacing="2" cellpadding="0">
-<tr class="section-bar">
-  <td colspan="3" align="left">
-  <div class="form-label"><h3>Index Contents</h3></div>
-  </td>
-</tr>
-<tr>
-  <td colspan="3" align="left">
-  <p class="form-help">The following table gives information that is
-contained in the various indexes of the Catalog. In the case of
-Keyword or Text indexes, the results are returned as a tuple, and will 
-show as '(one, two, three)', rather than in a more normal way.</p><br />
-  </td>
-</tr>
-<dtml-in expr="getIndexDataForRID(_.int(rid)).items()">
-<dtml-if name="sequence-start">
-<tr class="list-header">
-  <td align="left" width="5%" bgcolor="#ffffff">&nbsp;</td>
-  <td align="left" width="25%" valign="top" class="list-item">Key</td>
-  <td align="left" width="70%" valign="top" class="list-item">Value</td>
-</dtml-if>
-<dtml-if name="sequence-odd"><tr class="row-hilite">
-<dtml-else><tr></dtml-if>
-  <td width="32" bgcolor="#ffffff">&nbsp;</td>
-  <td align="left" valign="top" class="form-element">
-    &dtml-sequence-key;
-  </td>
-  <td align="left" valign="top" class="form-element">
-    &dtml-sequence-item;
-  </td>
-</tr>
-</dtml-in>
+<p>
+	<strong>1. Metadata Contents: </strong>
+	Metadata is the information that the Catalog
+	keeps inside of its internal structure so that it can answer
+	questions quickly.  This is then returned in the "brain" that the
+	Catalog gives back during searches.
+</p>
+<table title="Metadata Contents" 
+	class="table table-sm table-striped table-hover objectItems">
+	<dtml-in expr="getMetadataForRID(_.int(rid)).items()">
+		<dtml-if name="sequence-start">
+			<thead class="thead-light">
+				<tr>
+					<th width="25%">Key</th>
+					<th width="70%">Value</th>
+				</tr>
+			</thead>
+			<tbody>
+		</dtml-if>
+		<tr>
+			<td>&dtml-sequence-key;</td>
+			<td>&dtml-sequence-item;</td>
+		</tr>
+	</dtml-in>
+	</tbody>
 </table>
 
-</main>
-
-<dtml-var manage_page_footer>
+<p>
+	<strong>2. Index Contents: </strong>
+	The following table gives information that is
+	contained in the various indexes of the Catalog. In the case of
+	Keyword or Text indexes, the results are returned as a tuple, and will 
+	show as '(one, two, three)', rather than in a more normal way.
+</p>
+<table title="Index Contents" 
+	class="table table-sm table-striped table-hover objectItems">
+	<dtml-in expr="getIndexDataForRID(_.int(rid)).items()">
+		<dtml-if name="sequence-start">
+			<thead class="thead-light">
+				<tr>
+					<th width="25%">Key</th>
+					<th width="70%">Value</th>
+				</tr>
+			</thead>
+			<tbody>
+		</dtml-if>
+		<tr>
+			<td>&dtml-sequence-key;</td>
+			<td>&dtml-sequence-item;</td>
+		</tr>
+	</dtml-in>
+	</tbody>
+</table>

--- a/src/Products/ZCatalog/dtml/catalogObjectInformation.dtml
+++ b/src/Products/ZCatalog/dtml/catalogObjectInformation.dtml
@@ -1,67 +1,67 @@
 <h3 class="mt-2">
-	Catalog record at 
-	<code>
-		<dtml-var expr="getpath(_.int(rid))" html_quote>
-	</code>
+    Catalog record at 
+    <code>
+        <dtml-var expr="getpath(_.int(rid))" html_quote>
+    </code>
 </h3>
 <p>
-	The goal of this page is to provide basic debugging information
-	about what is in the Catalog on a specific object. Listed below is
-	all the information that the Catalog currently contains for the
-	above specified object. This information should match what is
-	currently in the instance of that object.
+    The goal of this page is to provide basic debugging information
+    about what is in the Catalog on a specific object. Listed below is
+    all the information that the Catalog currently contains for the
+    above specified object. This information should match what is
+    currently in the instance of that object.
 </p>
 
 <p>
-	<strong>1. Metadata Contents: </strong>
-	Metadata is the information that the Catalog
-	keeps inside of its internal structure so that it can answer
-	questions quickly.  This is then returned in the "brain" that the
-	Catalog gives back during searches.
+    <strong>1. Metadata Contents: </strong>
+    Metadata is the information that the Catalog
+    keeps inside of its internal structure so that it can answer
+    questions quickly.  This is then returned in the "brain" that the
+    Catalog gives back during searches.
 </p>
 <table title="Metadata Contents" 
-	class="table table-sm table-striped table-hover objectItems">
-	<dtml-in expr="getMetadataForRID(_.int(rid)).items()">
-		<dtml-if name="sequence-start">
-			<thead class="thead-light">
-				<tr>
-					<th width="25%">Key</th>
-					<th width="70%">Value</th>
-				</tr>
-			</thead>
-			<tbody>
-		</dtml-if>
-		<tr>
-			<td>&dtml-sequence-key;</td>
-			<td>&dtml-sequence-item;</td>
-		</tr>
-	</dtml-in>
-	</tbody>
+    class="table table-sm table-striped table-hover objectItems">
+    <dtml-in expr="getMetadataForRID(_.int(rid)).items()">
+        <dtml-if name="sequence-start">
+            <thead class="thead-light">
+                <tr>
+                    <th width="25%">Key</th>
+                    <th width="70%">Value</th>
+                </tr>
+            </thead>
+            <tbody>
+        </dtml-if>
+        <tr>
+            <td>&dtml-sequence-key;</td>
+            <td>&dtml-sequence-item;</td>
+        </tr>
+    </dtml-in>
+    </tbody>
 </table>
 
 <p>
-	<strong>2. Index Contents: </strong>
-	The following table gives information that is
-	contained in the various indexes of the Catalog. In the case of
-	Keyword or Text indexes, the results are returned as a tuple, and will 
-	show as '(one, two, three)', rather than in a more normal way.
+    <strong>2. Index Contents: </strong>
+    The following table gives information that is
+    contained in the various indexes of the Catalog. In the case of
+    Keyword or Text indexes, the results are returned as a tuple, and will 
+    show as '(one, two, three)', rather than in a more normal way.
 </p>
 <table title="Index Contents" 
-	class="table table-sm table-striped table-hover objectItems">
-	<dtml-in expr="getIndexDataForRID(_.int(rid)).items()">
-		<dtml-if name="sequence-start">
-			<thead class="thead-light">
-				<tr>
-					<th width="25%">Key</th>
-					<th width="70%">Value</th>
-				</tr>
-			</thead>
-			<tbody>
-		</dtml-if>
-		<tr>
-			<td>&dtml-sequence-key;</td>
-			<td>&dtml-sequence-item;</td>
-		</tr>
-	</dtml-in>
-	</tbody>
+    class="table table-sm table-striped table-hover objectItems">
+    <dtml-in expr="getIndexDataForRID(_.int(rid)).items()">
+        <dtml-if name="sequence-start">
+            <thead class="thead-light">
+                <tr>
+                    <th width="25%">Key</th>
+                    <th width="70%">Value</th>
+                </tr>
+            </thead>
+            <tbody>
+        </dtml-if>
+        <tr>
+            <td>&dtml-sequence-key;</td>
+            <td>&dtml-sequence-item;</td>
+        </tr>
+    </dtml-in>
+    </tbody>
 </table>

--- a/src/Products/ZCatalog/dtml/catalogPlan.dtml
+++ b/src/Products/ZCatalog/dtml/catalogPlan.dtml
@@ -3,14 +3,14 @@
 
 <main class="container-fluid">
 
-<p class="form-help"> 
-    The <strong>query plan</strong> shows the actual query plan of the
-    current process.
-</p>
+	<p class="form-help"> 
+		The <strong>query plan</strong> shows the actual query plan of the
+		current process.
+	</p>
 
-<textarea name="queryplan" cols="70" rows="25" readonly="readonly">
-&dtml-getCatalogPlan;
-</textarea>
+	<textarea  name="queryplan" cols="70" rows="25" readonly="readonly" 
+		class="form-control text-monospace code">&dtml-getCatalogPlan;
+	</textarea>
 
 </main>
 

--- a/src/Products/ZCatalog/dtml/catalogPlan.dtml
+++ b/src/Products/ZCatalog/dtml/catalogPlan.dtml
@@ -3,14 +3,14 @@
 
 <main class="container-fluid">
 
-	<p class="form-help"> 
-		The <strong>query plan</strong> shows the actual query plan of the
-		current process.
-	</p>
+    <p class="form-help"> 
+        The <strong>query plan</strong> shows the actual query plan of the
+        current process.
+    </p>
 
-	<textarea  name="queryplan" cols="70" rows="25" readonly="readonly" 
-		class="form-control text-monospace code">&dtml-getCatalogPlan;
-	</textarea>
+    <textarea  name="queryplan" cols="70" rows="25" readonly="readonly" 
+        class="form-control text-monospace code">&dtml-getCatalogPlan;
+    </textarea>
 
 </main>
 

--- a/src/Products/ZCatalog/dtml/catalogReport.dtml
+++ b/src/Products/ZCatalog/dtml/catalogReport.dtml
@@ -3,122 +3,87 @@
 
 <main class="container-fluid">
 
-<p class="form-help"> 
-   The <strong>query report</strong> shows catalog queries that perform slowly.
-   For each index there's an additional entry for the time the intersection of
-   the index result with the result by the other indexes took. These are marked
-   with a <i>#intersection</i> postfix. The time reported for the index is the
-   sum of the intersection time and the time the index itself took. Subtract
-   the intersection time, if you want to know the pure index time.
-</p>
+	<p class="form-help"> 
+		The <strong>query report</strong> shows catalog queries that perform slowly.
+		For each index there's an additional entry for the time the intersection of
+		the index result with the result by the other indexes took. These are marked
+		with a <i>#intersection</i> postfix. The time reported for the index is the
+		sum of the intersection time and the time the index itself took. Subtract
+		the intersection time, if you want to know the pure index time.
+	</p>
 
-<table width="100%" cellspacing="0" cellpadding="2" border="0">
-    <tr class="list-header" >
-        <td align="left" valign="top">
-            <div class="list-nav">
-                Mean duration&nbsp;[ms]
-            </div>
-        </td>
-        <td align="left" valign="top">
-            <div class="list-nav">
-                Hits
-            </div>
-        </td>
-        <td align="left" valign="top">
-            <div class="list-nav">
-                Query key
-            </div>
-        </td>
-        <td align="left" valign="top">
-            <div class="list-nav">
-                Recent
-            </div>
-        </td>
-    </tr>
-    <dtml-if getCatalogReport>
-        <dtml-in getCatalogReport mapping>
-            <dtml-if sequence-odd>
-                <tr class="row-normal">
-            <dtml-else>
-                <tr class="row-hilite">
-            </dtml-if>
-                    <td align="left" valign="top">
-                        <div class="list-item">
-                            <dtml-var expr="'%3.2f' % duration">
-                        </div>
-                    </td>
-                    <td align="left" valign="top">
-                        <div class="list-item">
-                            &dtml-counter;
-                        </div>
-                    </td>
-                    <td align="left" valign="top">
-                        <div class="list-item">
-                            &dtml-query;
-                        </div>
-                    </td>
-                    <td align="left" valign="top">
-                        <div class="list-item">
-                            <dtml-var expr="'%3.2f' % last['duration']">ms
-                            [<dtml-in expr="last['details']" sort mapping>
-                            &dtml-id;:
-                            <dtml-var expr="'%3.2f' % duration">ms,
-                            </dtml-in>]
-                        </div>
-                    </td>
-                </tr>
-        </dtml-in>
-        <tr>
-            <td colspan="2" align="left" valign="top">
-                <p class="form-help">Resetting the catalog report will reinitialize the report log.</p>
-            </td>
-            <td colspan="2" align="right" valign="top">
-                <form action="manage_resetCatalogReport" method=POST>
-                    <div class="form-element">
-                        <input class="form-element" type="submit" value="Reset Report">
-                    </div>
-                </form>
-            </td>
-        </tr>
-    <dtml-else>
-        <tr>
-            <td colspan="4" >
-                <div class="list-item">
-                    Report is empty.
-                </div>
-            </td>
-        </tr>
-    </dtml-if>
-</table>
+	<table class="table table-sm table-striped table-bordered table-hover">
+		<thead class="thead-light">
+			<tr>
+				<th scope="col">Mean duration&nbsp;[ms]</th>
+				<th scope="col">Hits</th>
+				<th scope="col">Query key</th>
+				<th scope="col">Recent</th>
+			</tr>
+		</thead>
+		<tbody>
+			<dtml-if getCatalogReport>
+				<dtml-in getCatalogReport mapping>
+					<tr>
+						<td>
+							<dtml-var expr="'%3.2f' % duration">
+						</td>
+						<td>
+							&dtml-counter;
+						</td>
+						<td>
+							&dtml-query;
+						</td>
+						<td>
+							<dtml-var expr="'%3.2f' % last['duration']">ms
+							[<dtml-in expr="last['details']" sort mapping>
+								&dtml-id;: <dtml-var expr="'%3.2f' % duration">ms,
+							</dtml-in>]
+						</td>
+					</tr>
+				</dtml-in>
+				<tr>
+					<td colspan="2">
+						Resetting the catalog report will reinitialize the report log.
+					</td>
+					<td colspan="2">
+						<form action="manage_resetCatalogReport" method="POST">
+							<input class="btn btn-primary" type="submit" value="Reset Report">
+						</form>
+					</td>
+				</tr>
+			<dtml-else>
+				<tr>
+					<td colspan="4" >
+						<em>Report is empty.</em>
+					</td>
+				</tr>
+			</dtml-if>
+		</tbody>
+	</table>
 
-<form action="manage_editCatalogReport" method="post">
-    <table width="100%" style="padding-top:1em;" cellspacing="0" cellpadding="2" border="0">
-        <tr class="section-bar">
-            <td colspan="3" align="left">
-                <div class="form-label">
-                    Settings
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td align="right" valign="middle">
-                <div class="list-item">
-                    Threshold (in seconds)
-                </div>
-            </td>
-            <td align="left" valign="middle">
-                <div class="form-element">
-                    <input name="long_query_time:float" value="&dtml-long_query_time;" />
-                </div>
-            </td>
-            <td align="left" valign="middle">
-                <p class="form-help">Only queries whose execution
-                takes longer than the configured threshold are considered
-                being slow. (Default 0.1 seconds).</p>
-        </tr>
-    </table>
-    <input class="form-element" type="submit" value="Apply settings">
-</form>
+	<form action="manage_editCatalogReport" method="post" class="mt-5">
+		<p class="help-text">
+			<strong>Settings:</strong> 
+			Threshold in seconds
+		</p>
+		<div class="form-group row">
+			<div class="col-12">
+				<input id="long_query_time" class="form-control" name="long_query_time:float"
+					title="Threshold in seconds" type="number" step="0.1"
+					value="&dtml-long_query_time;" placeholder="0.1" 
+				/>
+				<small><em>
+					Only queries whose execution takes longer than the 
+					configured threshold in seconds are considered 
+					being slow. (Default value is 0.1 seconds).
+				</em></small>
+			</div>
+		</div>
+		<div class="zmi-controls">
+			<input class="btn btn-primary" type="submit" value="Apply settings" />
+		</div>
+	</form>
 
 </main>
 

--- a/src/Products/ZCatalog/dtml/catalogReport.dtml
+++ b/src/Products/ZCatalog/dtml/catalogReport.dtml
@@ -3,87 +3,87 @@
 
 <main class="container-fluid">
 
-	<p class="form-help"> 
-		The <strong>query report</strong> shows catalog queries that perform slowly.
-		For each index there's an additional entry for the time the intersection of
-		the index result with the result by the other indexes took. These are marked
-		with a <i>#intersection</i> postfix. The time reported for the index is the
-		sum of the intersection time and the time the index itself took. Subtract
-		the intersection time, if you want to know the pure index time.
-	</p>
+    <p class="form-help"> 
+        The <strong>query report</strong> shows catalog queries that perform slowly.
+        For each index there's an additional entry for the time the intersection of
+        the index result with the result by the other indexes took. These are marked
+        with a <i>#intersection</i> postfix. The time reported for the index is the
+        sum of the intersection time and the time the index itself took. Subtract
+        the intersection time, if you want to know the pure index time.
+    </p>
 
-	<table class="table table-sm table-striped table-bordered table-hover">
-		<thead class="thead-light">
-			<tr>
-				<th scope="col">Mean duration&nbsp;[ms]</th>
-				<th scope="col">Hits</th>
-				<th scope="col">Query key</th>
-				<th scope="col">Recent</th>
-			</tr>
-		</thead>
-		<tbody>
-			<dtml-if getCatalogReport>
-				<dtml-in getCatalogReport mapping>
-					<tr>
-						<td>
-							<dtml-var expr="'%3.2f' % duration">
-						</td>
-						<td>
-							&dtml-counter;
-						</td>
-						<td>
-							&dtml-query;
-						</td>
-						<td>
-							<dtml-var expr="'%3.2f' % last['duration']">ms
-							[<dtml-in expr="last['details']" sort mapping>
-								&dtml-id;: <dtml-var expr="'%3.2f' % duration">ms,
-							</dtml-in>]
-						</td>
-					</tr>
-				</dtml-in>
-				<tr>
-					<td colspan="2">
-						Resetting the catalog report will reinitialize the report log.
-					</td>
-					<td colspan="2">
-						<form action="manage_resetCatalogReport" method="POST">
-							<input class="btn btn-primary" type="submit" value="Reset Report">
-						</form>
-					</td>
-				</tr>
-			<dtml-else>
-				<tr>
-					<td colspan="4" >
-						<em>Report is empty.</em>
-					</td>
-				</tr>
-			</dtml-if>
-		</tbody>
-	</table>
+    <table class="table table-sm table-striped table-bordered table-hover">
+        <thead class="thead-light">
+            <tr>
+                <th scope="col">Mean duration&nbsp;[ms]</th>
+                <th scope="col">Hits</th>
+                <th scope="col">Query key</th>
+                <th scope="col">Recent</th>
+            </tr>
+        </thead>
+        <tbody>
+            <dtml-if getCatalogReport>
+                <dtml-in getCatalogReport mapping>
+                    <tr>
+                        <td>
+                            <dtml-var expr="'%3.2f' % duration">
+                        </td>
+                        <td>
+                            &dtml-counter;
+                        </td>
+                        <td>
+                            &dtml-query;
+                        </td>
+                        <td>
+                            <dtml-var expr="'%3.2f' % last['duration']">ms
+                            [<dtml-in expr="last['details']" sort mapping>
+                                &dtml-id;: <dtml-var expr="'%3.2f' % duration">ms,
+                            </dtml-in>]
+                        </td>
+                    </tr>
+                </dtml-in>
+                <tr>
+                    <td colspan="2">
+                        Resetting the catalog report will reinitialize the report log.
+                    </td>
+                    <td colspan="2">
+                        <form action="manage_resetCatalogReport" method="POST">
+                            <input class="btn btn-primary" type="submit" value="Reset Report">
+                        </form>
+                    </td>
+                </tr>
+            <dtml-else>
+                <tr>
+                    <td colspan="4" >
+                        <em>Report is empty.</em>
+                    </td>
+                </tr>
+            </dtml-if>
+        </tbody>
+    </table>
 
-	<form action="manage_editCatalogReport" method="post" class="mt-5">
-		<p class="help-text">
-			<strong>Settings:</strong> 
-			Threshold in seconds
-		</p>
-		<div class="form-group row">
-			<div class="col-12">
-				<input id="long_query_time" class="form-control" name="long_query_time:float"
-					title="Threshold in seconds" type="number" step="0.1"
-					value="&dtml-long_query_time;" placeholder="0.1" 
-				/>
-				<small><em>
-					Only queries whose execution takes longer than the 
-					configured threshold in seconds are considered 
-					being slow. (Default value is 0.1 seconds).
-				</em></small>
-			</div>
-		</div>
-		<div class="zmi-controls">
-			<input class="btn btn-primary" type="submit" value="Apply settings" />
-		</div>
-	</form>
+    <form action="manage_editCatalogReport" method="post" class="mt-5">
+        <p class="help-text">
+            <strong>Settings:</strong> 
+            Threshold in seconds
+        </p>
+        <div class="form-group row">
+            <div class="col-12">
+                <input id="long_query_time" class="form-control" name="long_query_time:float"
+                    title="Threshold in seconds" type="number" step="0.1"
+                    value="&dtml-long_query_time;" placeholder="0.1" 
+                />
+                <small><em>
+                    Only queries whose execution takes longer than the 
+                    configured threshold in seconds are considered 
+                    being slow. (Default value is 0.1 seconds).
+                </em></small>
+            </div>
+        </div>
+        <div class="zmi-controls">
+            <input class="btn btn-primary" type="submit" value="Apply settings" />
+        </div>
+    </form>
 
 </main>
 

--- a/src/Products/ZCatalog/dtml/catalogSchema.dtml
+++ b/src/Products/ZCatalog/dtml/catalogSchema.dtml
@@ -4,54 +4,54 @@
 
 <main class="container-fluid">
 
-	<p class="form-help">
-		This list defines what per object meta data the Catalog will store. 
-		When objects get cataloged, the values of any attributes they may have 
-		which match a name in this list will get stored in a table in the 
-		Catalog.  The Catalog then uses this information to create result 
-		objects that are returned whenever the catalog is searched. It is 
-		important to understand that when the Catalog is searched, it returns 
-		a list of result objects, <em>not the cataloged objects themselves</em>, 
-		so if you want to use the value of an object's attribute in the result 
-		of a search, that attribute must be in this list.
-		<br />
-		It is generally a good idea to keep this list lightweight. It is 
-		useful, for example, to keep the 'summary' meta data of a text 
-		document (like the first 200 characters) but <i>not</i> the text 
-		content in it's entirety (it is useful in this example to <em>index</em> 
-		the text contents, which is configured in the <strong>Indexes</strong> View 
-		tab). This way, the summary data may be shown in the search results.
-	</p>
+    <p class="form-help">
+        This list defines what per object meta data the Catalog will store. 
+        When objects get cataloged, the values of any attributes they may have 
+        which match a name in this list will get stored in a table in the 
+        Catalog.  The Catalog then uses this information to create result 
+        objects that are returned whenever the catalog is searched. It is 
+        important to understand that when the Catalog is searched, it returns 
+        a list of result objects, <em>not the cataloged objects themselves</em>, 
+        so if you want to use the value of an object's attribute in the result 
+        of a search, that attribute must be in this list.
+        <br />
+        It is generally a good idea to keep this list lightweight. It is 
+        useful, for example, to keep the 'summary' meta data of a text 
+        document (like the first 200 characters) but <i>not</i> the text 
+        content in it's entirety (it is useful in this example to <em>index</em> 
+        the text contents, which is configured in the <strong>Indexes</strong> View 
+        tab). This way, the summary data may be shown in the search results.
+    </p>
 
-	<form action="&dtml-URL1;">
+    <form action="&dtml-URL1;">
 
-		<dtml-in schema sort=sequence-item>
-			<div class="form-check">
-				<input type="checkbox" class="form-check-input" id="&dtml-sequence-item;" name="names:list" value="&dtml-sequence-item;" />
-				<label class="form-check-label" for="&dtml-sequence-item;">&dtml-sequence-item;</label>
-			</div>
-			<dtml-if sequence-end>
-				<div class="zmi-controls">
-					<input class="btn btn-primary" type="submit" name="manage_delColumn:method" value="Delete" /> 
-				</div>
-			</dtml-if>
-		<dtml-else>
-			<div class="alert alert-info">There are currently no metadata elements.</div>
-		</dtml-in>
+        <dtml-in schema sort=sequence-item>
+            <div class="form-check">
+                <input type="checkbox" class="form-check-input" id="&dtml-sequence-item;" name="names:list" value="&dtml-sequence-item;" />
+                <label class="form-check-label" for="&dtml-sequence-item;">&dtml-sequence-item;</label>
+            </div>
+            <dtml-if sequence-end>
+                <div class="zmi-controls">
+                    <input class="btn btn-primary" type="submit" name="manage_delColumn:method" value="Delete" /> 
+                </div>
+            </dtml-if>
+        <dtml-else>
+            <div class="alert alert-info">There are currently no metadata elements.</div>
+        </dtml-in>
 
-		<div class="form-group my-4">
-			<div class="input-group">
-				<div class="input-group-prepend">
-					<span class="input-group-text">Add Metadata</span>
-				</div>
-				<input class="form-control" type="text" name="name" value="" />
-				<div class="input-group-append">
-					<input class="btn btn-primary" type="submit" name="manage_addColumn:method" value="Add" />
-				</div>
-			</div>
-		</div>
+        <div class="form-group my-4">
+            <div class="input-group">
+                <div class="input-group-prepend">
+                    <span class="input-group-text">Add Metadata</span>
+                </div>
+                <input class="form-control" type="text" name="name" value="" />
+                <div class="input-group-append">
+                    <input class="btn btn-primary" type="submit" name="manage_addColumn:method" value="Add" />
+                </div>
+            </div>
+        </div>
 
-	</form>
+    </form>
 
 </main>
 

--- a/src/Products/ZCatalog/dtml/catalogSchema.dtml
+++ b/src/Products/ZCatalog/dtml/catalogSchema.dtml
@@ -9,13 +9,13 @@
 		When objects get cataloged, the values of any attributes they may have 
 		which match a name in this list will get stored in a table in the 
 		Catalog.  The Catalog then uses this information to create result 
-		objects that are returned whenever the catalog is searched.  It is 
+		objects that are returned whenever the catalog is searched. It is 
 		important to understand that when the Catalog is searched, it returns 
 		a list of result objects, <em>not the cataloged objects themselves</em>, 
 		so if you want to use the value of an object's attribute in the result 
-		of a search, that attribute must be in this list
+		of a search, that attribute must be in this list.
 		<br />
-		It is generally a good idea to keep this list lightweight.  It is 
+		It is generally a good idea to keep this list lightweight. It is 
 		useful, for example, to keep the 'summary' meta data of a text 
 		document (like the first 200 characters) but <i>not</i> the text 
 		content in it's entirety (it is useful in this example to <em>index</em> 
@@ -39,17 +39,16 @@
 			<div class="alert alert-info">There are currently no metadata elements.</div>
 		</dtml-in>
 
-
-		<div class="form-group mt-4 mb-4">
-					<div class="input-group">
-						<div class="input-group-prepend">
-							<span class="input-group-text">Add Metadata</span>
-						</div>
-						<input class="form-control" type="text" name="name" value="" />
-						<div class="input-group-append">
-							<input class="btn btn-primary"" type="submit" name="manage_addColumn:method" value="Add" />
-					</div>
+		<div class="form-group my-4">
+			<div class="input-group">
+				<div class="input-group-prepend">
+					<span class="input-group-text">Add Metadata</span>
 				</div>
+				<input class="form-control" type="text" name="name" value="" />
+				<div class="input-group-append">
+					<input class="btn btn-primary" type="submit" name="manage_addColumn:method" value="Add" />
+				</div>
+			</div>
 		</div>
 
 	</form>

--- a/src/Products/ZCatalog/dtml/catalogStatus.dtml
+++ b/src/Products/ZCatalog/dtml/catalogStatus.dtml
@@ -5,12 +5,11 @@
 
     <p class="form-help"> Subtransactions allow Zope to commit small
       parts of a transaction over a period of time instead of all at once.
-      For
-      ZCatalog, this means using subtransactions can signficantly
+      For ZCatalog, this means using subtransactions can signficantly
       reduce the memory requirements needed to index huge amounts of
       text all at once.</p>
     
-    <p class="form-help"> If enabled, subtransactions will reduce the memory
+    <p class="form-help">If enabled, subtransactions will reduce the memory
       requirements of ZCatalog, but <em>at the expense of speed</em>.
       If you choose to enable subtransactions, you can adjust how often
       ZCatalog commits a subtransactions by adjusting the

--- a/src/Products/ZCatalog/dtml/catalogView.dtml
+++ b/src/Products/ZCatalog/dtml/catalogView.dtml
@@ -3,160 +3,160 @@
 
 <main class="container-fluid">
 
-	<dtml-let filterpath="REQUEST.get('filterpath', '')"
-		results="searchResults(path=filterpath) if filterpath else searchAll()">
-		<dtml-if results>
-			<dtml-if "'path' in this().indexes()">
-				<form action="&dtml-URL;" class="row" title="Path filter">
-					<div class="form-row col-12 px-3">
-						<div class="input-group form-inline">
-							<div class="input-group-prepend">
-								<button type="submit" class="btn btn-secondary">Set Path Filter</button>
-							</div>
-								<input type="text" class="form-control text-monospace" name="filterpath" value="&dtml-filterpath;" placeholder="/path">
-						</div>
-					</div>
-				</form>
-			<dtml-else>
-				<p class="help-text">
-					The path filter is <span style="color:red;">disabled</span>. To enable the path filter, add a PathIndex called "path" to this catalog.
-				</p>
-			</dtml-if>
+    <dtml-let filterpath="REQUEST.get('filterpath', '')"
+        results="searchResults(path=filterpath) if filterpath else searchAll()">
+        <dtml-if results>
+            <dtml-if "'path' in this().indexes()">
+                <form action="&dtml-URL;" class="row" title="Path filter">
+                    <div class="form-row col-12 px-3">
+                        <div class="input-group form-inline">
+                            <div class="input-group-prepend">
+                                <button type="submit" class="btn btn-secondary">Set Path Filter</button>
+                            </div>
+                                <input type="text" class="form-control text-monospace" name="filterpath" value="&dtml-filterpath;" placeholder="/path">
+                        </div>
+                    </div>
+                </form>
+            <dtml-else>
+                <p class="help-text">
+                    The path filter is <span style="color:red;">disabled</span>. To enable the path filter, add a PathIndex called "path" to this catalog.
+                </p>
+            </dtml-if>
 
-			<h2 class="zmi-title mt-4">Objects in this catalog</h2>
+            <h2 class="zmi-title mt-4">Objects in this catalog</h2>
 
-			<form action="&dtml-URL1;" name="objectItems" id="objectItems">
-				<p class="help-text">
-					The catalog <em>&dtml-id;</em> contains 
-					<span class="badge badge-success">
-						<dtml-var results fmt=collection-length thousands_commas> 
-					</span>
-					record(s)
-					<dtml-if filterpath>
-						in the path <code>&dtml-filterpath;</code>
-					</dtml-if>
-				</p>
-				<nav class="zmi-find-results nav mb-3">
-					<div class="col-6 text-left pl-1">
-						<dtml-in results previous size=20 start=query_start >
-							<a class="btn btn-primary"
-								href="&dtml-URL;?query_start=&dtml-previous-sequence-start-number;&filterpath=&dtml-filterpath;">
-								<i class="fas fa-chevron-left mr-2"></i>
-								Previous <dtml-var previous-sequence-size> entries
-							</a>
-						</dtml-in>
-					</div>
-					<div class="col-6 text-right pr-1">
-						<dtml-in results next size=20 start=query_start >
-							<a class="btn btn-primary"
-								href="&dtml-URL;?query_start=&dtml-next-sequence-start-number;&filterpath=&dtml-filterpath;">
-								Next <dtml-var next-sequence-size> entries
-								<i class="fas fa-chevron-right ml-2"></i>
-							</a>
-						</dtml-in>
-					</div>
-				</nav>
-				<table class="table table-sm table-striped table-hover objectItems">
-					<dtml-in results size=20 start=query_start >
-						<dtml-if name="sequence-start">
-							<thead class="thead-light">
-								<tr>
-									<th scope="col" class="zmi-object-check text-right">
-										<input type="checkbox" id="checkAll" onclick="checkbox_all();" />
-									</th>
-									<th scope="col" class="zmi-object-id">
-										Object Identifier
-									</th>
-									<th scope="col">
-										Type
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-						</dtml-if>
-						<tr>
-							<td class="zmi-object-check text-right" onclick="$(this).children('input').trigger('click');">
-								<input class="checkbox-list-item" type="checkbox" name="urls:list" value="&dtml-getPath;"
-									onclick="event.stopPropagation();select_objectitem($(this));" />
-							</td>
-							<td class="zmi-object-id">
-								<a href="#" onclick="showItem('&dtml-URL1;/manage_objectInformation?rid=&dtml-getRID;')">
-									&dtml-getPath;
-								</a>
-							</td>
-							<td>
-								<dtml-if expr="has_key('meta_type') and meta_type">
-									<dtml-var name="meta_type" size="15" html_quote>
-								<dtml-else>
-									<em>Unknown</em>
-								</dtml-if>
-							</td>
-						</tr>
-					</dtml-in>
-					</tbody>
-				</table>
-				<div class="zmi-controls">
-					<input class="btn btn-primary" type="submit" value=" Remove " name="manage_uncatalogObject:method" />
-					<input class="btn btn-primary" type="submit" value=" Update " name="manage_catalogObject:method" />
-				</div>
-			</form>
-		<dtml-else>
-			<p class="helo-text">
-				There are no objects in the Catalog.
-			</p>
-		</dtml-if>
-	</dtml-let>
+            <form action="&dtml-URL1;" name="objectItems" id="objectItems">
+                <p class="help-text">
+                    The catalog <em>&dtml-id;</em> contains 
+                    <span class="badge badge-success">
+                        <dtml-var results fmt=collection-length thousands_commas> 
+                    </span>
+                    record(s)
+                    <dtml-if filterpath>
+                        in the path <code>&dtml-filterpath;</code>
+                    </dtml-if>
+                </p>
+                <nav class="zmi-find-results nav mb-3">
+                    <div class="col-6 text-left pl-1">
+                        <dtml-in results previous size=20 start=query_start >
+                            <a class="btn btn-primary"
+                                href="&dtml-URL;?query_start=&dtml-previous-sequence-start-number;&filterpath=&dtml-filterpath;">
+                                <i class="fas fa-chevron-left mr-2"></i>
+                                Previous <dtml-var previous-sequence-size> entries
+                            </a>
+                        </dtml-in>
+                    </div>
+                    <div class="col-6 text-right pr-1">
+                        <dtml-in results next size=20 start=query_start >
+                            <a class="btn btn-primary"
+                                href="&dtml-URL;?query_start=&dtml-next-sequence-start-number;&filterpath=&dtml-filterpath;">
+                                Next <dtml-var next-sequence-size> entries
+                                <i class="fas fa-chevron-right ml-2"></i>
+                            </a>
+                        </dtml-in>
+                    </div>
+                </nav>
+                <table class="table table-sm table-striped table-hover objectItems">
+                    <dtml-in results size=20 start=query_start >
+                        <dtml-if name="sequence-start">
+                            <thead class="thead-light">
+                                <tr>
+                                    <th scope="col" class="zmi-object-check text-right">
+                                        <input type="checkbox" id="checkAll" onclick="checkbox_all();" />
+                                    </th>
+                                    <th scope="col" class="zmi-object-id">
+                                        Object Identifier
+                                    </th>
+                                    <th scope="col">
+                                        Type
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                        </dtml-if>
+                        <tr>
+                            <td class="zmi-object-check text-right" onclick="$(this).children('input').trigger('click');">
+                                <input class="checkbox-list-item" type="checkbox" name="urls:list" value="&dtml-getPath;"
+                                    onclick="event.stopPropagation();select_objectitem($(this));" />
+                            </td>
+                            <td class="zmi-object-id">
+                                <a href="#" onclick="showItem('&dtml-URL1;/manage_objectInformation?rid=&dtml-getRID;')">
+                                    &dtml-getPath;
+                                </a>
+                            </td>
+                            <td>
+                                <dtml-if expr="has_key('meta_type') and meta_type">
+                                    <dtml-var name="meta_type" size="15" html_quote>
+                                <dtml-else>
+                                    <em>Unknown</em>
+                                </dtml-if>
+                            </td>
+                        </tr>
+                    </dtml-in>
+                    </tbody>
+                </table>
+                <div class="zmi-controls">
+                    <input class="btn btn-primary" type="submit" value=" Remove " name="manage_uncatalogObject:method" />
+                    <input class="btn btn-primary" type="submit" value=" Update " name="manage_catalogObject:method" />
+                </div>
+            </form>
+        <dtml-else>
+            <p class="helo-text">
+                There are no objects in the Catalog.
+            </p>
+        </dtml-if>
+    </dtml-let>
 
 </main>
 
 <script>
 //<!--
-	// +++++++++++++++++++++++++++
-	// Item  Selection
-	// +++++++++++++++++++++++++++
-	function checkbox_all() {
-		var checkboxes = document.getElementsByClassName('checkbox-list-item');
-		// Toggle Highlighting CSS-Class
-		if (document.getElementById('checkAll').checked) {
-			$('table.objectItems tbody tr').addClass('checked');
-		} else {
-			$('table.objectItems tbody tr').removeClass('checked');
-		};
-		// Set Checkbox like checkAll-Box
-		for (i = 0; i < checkboxes.length; i++) {
-			checkboxes[i].checked = document.getElementById('checkAll').checked;
-		}
-	};
-	function select_objectitem(ob) {
-		ob.parent().parent().toggleClass('checked');
-		if ( !zmicontrols_visible() ) {
-			$('form#objectItems').addClass('selected');
-		}
-		// Anything selected?
-		var checkboxes = document.getElementsByClassName('checkbox-list-item');
-		var selected = false;
-		for (i = 0; i < checkboxes.length; i++) {
-			if ( checkboxes[i].checked ) {
-			selected = true;
-			break;
-			}
-		}
-		if ( !selected ) {
-			$('form#objectItems').removeClass('selected');
-			console.log('form#objectItems removed .selected');
-		}
-	};
-	function showItem( url ) {
-		$('#zmi-modal').modal('show');
-		$('#zmi-modal').modal({ focus: true });
-		// Load Modal Form by AJAX
-		$('#zmi-modal .modal-body').load( url );
-		// Clean up Modal DOM on Close
-		$('#zmi-modal').on('hide.bs.modal', function (event) {
-			$('#zmi-modal .modal-header h2').remove();
-			$('#zmi-modal .modal-body').empty();
-		});
-	};
+    // +++++++++++++++++++++++++++
+    // Item  Selection
+    // +++++++++++++++++++++++++++
+    function checkbox_all() {
+        var checkboxes = document.getElementsByClassName('checkbox-list-item');
+        // Toggle Highlighting CSS-Class
+        if (document.getElementById('checkAll').checked) {
+            $('table.objectItems tbody tr').addClass('checked');
+        } else {
+            $('table.objectItems tbody tr').removeClass('checked');
+        };
+        // Set Checkbox like checkAll-Box
+        for (i = 0; i < checkboxes.length; i++) {
+            checkboxes[i].checked = document.getElementById('checkAll').checked;
+        }
+    };
+    function select_objectitem(ob) {
+        ob.parent().parent().toggleClass('checked');
+        if ( !zmicontrols_visible() ) {
+            $('form#objectItems').addClass('selected');
+        }
+        // Anything selected?
+        var checkboxes = document.getElementsByClassName('checkbox-list-item');
+        var selected = false;
+        for (i = 0; i < checkboxes.length; i++) {
+            if ( checkboxes[i].checked ) {
+            selected = true;
+            break;
+            }
+        }
+        if ( !selected ) {
+            $('form#objectItems').removeClass('selected');
+            console.log('form#objectItems removed .selected');
+        }
+    };
+    function showItem( url ) {
+        $('#zmi-modal').modal('show');
+        $('#zmi-modal').modal({ focus: true });
+        // Load Modal Form by AJAX
+        $('#zmi-modal .modal-body').load( url );
+        // Clean up Modal DOM on Close
+        $('#zmi-modal').on('hide.bs.modal', function (event) {
+            $('#zmi-modal .modal-header h2').remove();
+            $('#zmi-modal .modal-body').empty();
+        });
+    };
 //-->
 </script>
 
@@ -166,17 +166,17 @@
 </script>
 
 <style>
-	/* OBJECT CLASS ZCatalog: Neutralize Zope Overwrites of zmi.base.css, L891 */
-	@media (min-width: 577px) {
-		body.zmi-ZCatalog {
-			min-width: unset !important;
-		}
-		body.zmi-ZCatalog:not(.zmi-manage_catalogFind) main.container-fluid {
-			width: unset !important;;
-			margin-right: auto;
-			margin-left: auto;
-		}
-	}
+    /* OBJECT CLASS ZCatalog: Neutralize Zope Overwrites of zmi.base.css, L891 */
+    @media (min-width: 577px) {
+        body.zmi-ZCatalog {
+            min-width: unset !important;
+        }
+        body.zmi-ZCatalog:not(.zmi-manage_catalogFind) main.container-fluid {
+            width: unset !important;;
+            margin-right: auto;
+            margin-left: auto;
+        }
+    }
 
 </style>
 

--- a/src/Products/ZCatalog/dtml/catalogView.dtml
+++ b/src/Products/ZCatalog/dtml/catalogView.dtml
@@ -25,7 +25,7 @@
 
 			<h2 class="zmi-title mt-4">Objects in this catalog</h2>
 
-			<form action="&dtml-URL1;" name="objectItems">
+			<form action="&dtml-URL1;" name="objectItems" id="objectItems">
 				<p class="help-text">
 					The catalog <em>&dtml-id;</em> contains 
 					<span class="badge badge-success">
@@ -56,46 +56,45 @@
 						</dtml-in>
 					</div>
 				</nav>
-				<div title="Cataloged Objects">
-					<table class="table table-sm table-striped table-bordered table-hover m-1 mb-3">
-						<dtml-in results size=20 start=query_start >
-							<dtml-if name="sequence-start">
-								<thead class="thead-light">
-									<tr>
-										<th scope="col" class="zmi-object-check text-center">
-											<input type="checkbox" id="checkAll" onclick="checkbox_all();"/>
-										</th>
-										<th scope="col">
-											Object Identifier
-										</th>
-										<th scope="col">
-											Type
-										</th>
-									</tr>
-								</thead>
-								<tbody>
-							</dtml-if>
+				<table class="table table-sm table-striped table-hover objectItems">
+					<dtml-in results size=20 start=query_start >
+						<dtml-if name="sequence-start">
+							<thead class="thead-light">
 								<tr>
-									<td class="zmi-object-check text-center">
-										<input class="checkbox-list-item" type="checkbox" name="urls:list" value="&dtml-getPath;" />
-									</td>
-									<td>
-										<a href="&dtml-URL1;/manage_objectInformation?rid=&dtml-getRID;"
-											target="_objectinfo_&dtml-getRID;">&dtml-getPath;
-										</a>
-									</td>
-									<td>
-										<dtml-if expr="has_key('meta_type') and meta_type">
-											<dtml-var name="meta_type" size="15" html_quote>
-										<dtml-else>
-											<em>Unknown</em>
-										</dtml-if>
-									</td>
+									<th scope="col" class="zmi-object-check text-right">
+										<input type="checkbox" id="checkAll" onclick="checkbox_all();" />
+									</th>
+									<th scope="col" class="zmi-object-id">
+										Object Identifier
+									</th>
+									<th scope="col">
+										Type
+									</th>
 								</tr>
-							</dtml-in>
-						</tbody>
-					</table>
-				</div>
+							</thead>
+							<tbody>
+						</dtml-if>
+						<tr>
+							<td class="zmi-object-check text-right" onclick="$(this).children('input').trigger('click');">
+								<input class="checkbox-list-item" type="checkbox" name="urls:list" value="&dtml-getPath;"
+									onclick="event.stopPropagation();select_objectitem($(this));" />
+							</td>
+							<td class="zmi-object-id">
+								<a href="#" onclick="showItem('&dtml-URL1;/manage_objectInformation?rid=&dtml-getRID;')">
+									&dtml-getPath;
+								</a>
+							</td>
+							<td>
+								<dtml-if expr="has_key('meta_type') and meta_type">
+									<dtml-var name="meta_type" size="15" html_quote>
+								<dtml-else>
+									<em>Unknown</em>
+								</dtml-if>
+							</td>
+						</tr>
+					</dtml-in>
+					</tbody>
+				</table>
 				<div class="zmi-controls">
 					<input class="btn btn-primary" type="submit" value=" Remove " name="manage_uncatalogObject:method" />
 					<input class="btn btn-primary" type="submit" value=" Update " name="manage_catalogObject:method" />
@@ -128,6 +127,41 @@
 			checkboxes[i].checked = document.getElementById('checkAll').checked;
 		}
 	};
+	function select_objectitem(ob) {
+		ob.parent().parent().toggleClass('checked');
+		if ( !zmicontrols_visible() ) {
+			$('form#objectItems').addClass('selected');
+		}
+		// Anything selected?
+		var checkboxes = document.getElementsByClassName('checkbox-list-item');
+		var selected = false;
+		for (i = 0; i < checkboxes.length; i++) {
+			if ( checkboxes[i].checked ) {
+			selected = true;
+			break;
+			}
+		}
+		if ( !selected ) {
+			$('form#objectItems').removeClass('selected');
+			console.log('form#objectItems removed .selected');
+		}
+	};
+	function showItem( url ) {
+		$('#zmi-modal').modal('show');
+		$('#zmi-modal').modal({ focus: true });
+		// Load Modal Form by AJAX
+		$('#zmi-modal .modal-body').load( url );
+		// Clean up Modal DOM on Close
+		$('#zmi-modal').on('hide.bs.modal', function (event) {
+			$('#zmi-modal .modal-header h2').remove();
+			$('#zmi-modal .modal-body').empty();
+		});
+	};
+//-->
+</script>
+
+
+
 //-->
 </script>
 

--- a/src/Products/ZCatalog/dtml/catalogView.dtml
+++ b/src/Products/ZCatalog/dtml/catalogView.dtml
@@ -3,92 +3,147 @@
 
 <main class="container-fluid">
 
-    <dtml-let filterpath="REQUEST.get('filterpath', '')"
-              results="searchResults(path=filterpath) if filterpath else searchAll()">
-<dtml-if results>
+	<dtml-let filterpath="REQUEST.get('filterpath', '')"
+		results="searchResults(path=filterpath) if filterpath else searchAll()">
+		<dtml-if results>
+			<dtml-if "'path' in this().indexes()">
+				<form action="&dtml-URL;" class="row" title="Path filter">
+					<div class="form-row col-12 px-3">
+						<div class="input-group form-inline">
+							<div class="input-group-prepend">
+								<button type="submit" class="btn btn-secondary">Set Path Filter</button>
+							</div>
+								<input type="text" class="form-control text-monospace" name="filterpath" value="&dtml-filterpath;" placeholder="/path">
+						</div>
+					</div>
+				</form>
+			<dtml-else>
+				<p class="help-text">
+					The path filter is <span style="color:red;">disabled</span>. To enable the path filter, add a PathIndex called "path" to this catalog.
+				</p>
+			</dtml-if>
 
-<h1 class="form-label section-bar">Path filter</h1>
-<dtml-if "'path' in this().indexes()">
-<form action="&dtml-URL;">
-    <p class="form-text">
-        Path: <input type="text" name="filterpath" value="&dtml-filterpath;"/> <input type="submit" value="Set Filter"/>
-    </p>
-</form>
-<dtml-else>
-    <p class="form-text">
-    The path filter is <span style="color:red;">disabled</span>. To enable the path filter, add a PathIndex called "path" to this catalog.
-    </p>
-</dtml-if>
+			<h2 class="zmi-title mt-4">Objects in this catalog</h2>
 
-<h1 class="form-label section-bar">Objects in this catalog</h1>
-
-<form action="&dtml-URL1;" name="objectItems">
-<p class="form-text">
-The catalog "&dtml-id;" contains <dtml-var results fmt=collection-length thousands_commas> record(s) in the path "&dtml-filterpath;".
-</p>
-<div class="form-text">
-  <dtml-in results previous size=20 start=query_start >
-      <a href="&dtml-URL;?query_start=&dtml-previous-sequence-start-number;&filterpath=&dtml-filterpath;">
-      [Previous <dtml-var previous-sequence-size> entries]
-    </a>
-  </dtml-in>
-  <dtml-in results next size=20 start=query_start >
-    <a href="&dtml-URL;?query_start=&dtml-next-sequence-start-number;&filterpath=&dtml-filterpath;">
-      [Next <dtml-var next-sequence-size> entries]
-    </a>
-  </dtml-in>
-  </div>
-
-<table width="100%" cellspacing="0" cellpadding="2" border="0">
-<dtml-in results size=20 start=query_start >
-  <dtml-if name="sequence-start">
-  <tr class="list-header">
-    <td width="5%" align="right" colspan="2" valign="top">&nbsp;</td>
-    <td width="80%" align="left" valign="top">
-      <div class="list-item">Object Identifier</div></td>
-    <td width="15%" align="left" valign="top">
-      <div class="list-item">Type</div></td>
-  </tr>
-  </dtml-if>
-  <dtml-if name="sequence-odd"><tr class="row-normal">
-  <dtml-else><tr class="row-hilite"></dtml-if>
-    <td align="right" valign="top">
-    <input type="checkbox" NAME="urls:list" VALUE="&dtml-getPath;">
-    </td>
-    <td align="left" valign="top">&nbsp;</td>
-    <td align="left" valign="top">
-    <div class="form-text">
-    <a href="&dtml-URL1;/manage_objectInformation?rid=&dtml-getRID;"
-     target="_objectinfo_&dtml-getRID;">&dtml-getPath;</a>
-    </div>
-    </td>
-    <td align="left" valign="top">
-    <div class="form-text">
-      <dtml-if expr="has_key('meta_type') and meta_type">
-        <dtml-var name="meta_type" size="15" html_quote>
-      <dtml-else>
-        <i>Unknown</i>
-      </dtml-if>
-    </div>
-    </td>
-  </tr>
-</dtml-in>
-</table>
-
-<div class="form-element">
-<input class="form-element" type="submit" value=" Remove " 
- name="manage_uncatalogObject:method">
-<input class="form-element" type="submit" value=" Update " 
- name="manage_catalogObject:method">
-</div>
-</form>
-<dtml-else>
-<p class="form-text">
-There are no objects in the Catalog.
-</p>
-</dtml-if>
-</dtml-let>
+			<form action="&dtml-URL1;" name="objectItems">
+				<p class="help-text">
+					The catalog <em>&dtml-id;</em> contains 
+					<span class="badge badge-success">
+						<dtml-var results fmt=collection-length thousands_commas> 
+					</span>
+					record(s)
+					<dtml-if filterpath>
+						in the path <code>&dtml-filterpath;</code>
+					</dtml-if>
+				</p>
+				<nav class="zmi-find-results nav mb-3">
+					<div class="col-6 text-left pl-1">
+						<dtml-in results previous size=20 start=query_start >
+							<a class="btn btn-primary"
+								href="&dtml-URL;?query_start=&dtml-previous-sequence-start-number;&filterpath=&dtml-filterpath;">
+								<i class="fas fa-chevron-left mr-2"></i>
+								Previous <dtml-var previous-sequence-size> entries
+							</a>
+						</dtml-in>
+					</div>
+					<div class="col-6 text-right pr-1">
+						<dtml-in results next size=20 start=query_start >
+							<a class="btn btn-primary"
+								href="&dtml-URL;?query_start=&dtml-next-sequence-start-number;&filterpath=&dtml-filterpath;">
+								Next <dtml-var next-sequence-size> entries
+								<i class="fas fa-chevron-right ml-2"></i>
+							</a>
+						</dtml-in>
+					</div>
+				</nav>
+				<div title="Cataloged Objects">
+					<table class="table table-sm table-striped table-bordered table-hover m-1 mb-3">
+						<dtml-in results size=20 start=query_start >
+							<dtml-if name="sequence-start">
+								<thead class="thead-light">
+									<tr>
+										<th scope="col" class="zmi-object-check text-center">
+											<input type="checkbox" id="checkAll" onclick="checkbox_all();"/>
+										</th>
+										<th scope="col">
+											Object Identifier
+										</th>
+										<th scope="col">
+											Type
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+							</dtml-if>
+								<tr>
+									<td class="zmi-object-check text-center">
+										<input class="checkbox-list-item" type="checkbox" name="urls:list" value="&dtml-getPath;" />
+									</td>
+									<td>
+										<a href="&dtml-URL1;/manage_objectInformation?rid=&dtml-getRID;"
+											target="_objectinfo_&dtml-getRID;">&dtml-getPath;
+										</a>
+									</td>
+									<td>
+										<dtml-if expr="has_key('meta_type') and meta_type">
+											<dtml-var name="meta_type" size="15" html_quote>
+										<dtml-else>
+											<em>Unknown</em>
+										</dtml-if>
+									</td>
+								</tr>
+							</dtml-in>
+						</tbody>
+					</table>
+				</div>
+				<div class="zmi-controls">
+					<input class="btn btn-primary" type="submit" value=" Remove " name="manage_uncatalogObject:method" />
+					<input class="btn btn-primary" type="submit" value=" Update " name="manage_catalogObject:method" />
+				</div>
+			</form>
+		<dtml-else>
+			<p class="helo-text">
+				There are no objects in the Catalog.
+			</p>
+		</dtml-if>
+	</dtml-let>
 
 </main>
+
+<script>
+//<!--
+	// +++++++++++++++++++++++++++
+	// Item  Selection
+	// +++++++++++++++++++++++++++
+	function checkbox_all() {
+		var checkboxes = document.getElementsByClassName('checkbox-list-item');
+		// Toggle Highlighting CSS-Class
+		if (document.getElementById('checkAll').checked) {
+			$('table.objectItems tbody tr').addClass('checked');
+		} else {
+			$('table.objectItems tbody tr').removeClass('checked');
+		};
+		// Set Checkbox like checkAll-Box
+		for (i = 0; i < checkboxes.length; i++) {
+			checkboxes[i].checked = document.getElementById('checkAll').checked;
+		}
+	};
+//-->
+</script>
+
+<style>
+	/* OBJECT CLASS ZCatalog: Neutralize Zope Overwrites of zmi.base.css, L891 */
+	@media (min-width: 577px) {
+		body.zmi-ZCatalog {
+			min-width: unset !important;
+		}
+		body.zmi-ZCatalog:not(.zmi-manage_catalogFind) main.container-fluid {
+			width: unset !important;;
+			margin-right: auto;
+			margin-left: auto;
+		}
+	}
+
+</style>
 
 <dtml-var manage_page_footer>

--- a/src/Products/ZCatalog/zpt/catalogIndexes.zpt
+++ b/src/Products/ZCatalog/zpt/catalogIndexes.zpt
@@ -4,146 +4,146 @@
 
 <main class="container-fluid">
 
-	<p class="form-help">
-		This list defines what indexes the Catalog will contain. When objects
-		get cataloged, the values of any attributes which match
-		an index in this list will get indexed. If you add indexes to a Catalog
-		which contains indexed objects, you MUST at the least re-index your newly
-		added index. You may want to update the whole Catalog.
-	</p>
-	<tal:indexes define="indexes context/Indexes">
-		<tal:add define="filtered_meta_types context/availableIndexes">
-			<form tal:attributes="action context/absolute_url" method="get">
-				<div class="form-group mt-4 mb-4">
-					<div class="input-group">
-						<div class="input-group-prepend">
-							<span class="input-group-text">Add <span class="d-sm-block d-none">&nbsp;new&nbsp;</span> Index:</span>
-						</div>
-							<tal:indexlist condition="python:len(filtered_meta_types) > 1">
-								<select id="addindex" class="form-control" name=":action"
-									onChange=""
-									tal:attributes="onChange string:location.href='${request/URL1}/'+this.options[this.selectedIndex].value">
-									<option value="manage_workspace" disabled>Select type to add...</option>
-									<tal:types repeat="indextype filtered_meta_types">
-										<option tal:attributes="value indextype/action"
-											tal:content="indextype/name"></option>
-									</tal:types>
-								</select>
-							</tal:indexlist>
-							<div class="input-group-append">
-								<input class="btn btn-primary" type="submit" name="submit" value="Add" />
-						</div>
-					</div>
-				</div>
-			</form>
-		</tal:add>
-		<form tal:attributes="action string:${request/URL1}/" name="objectItems" method="post">
-			<tal:items define="
-					skey python:request.get('skey','id');
-					rkey python:request.get('rkey','asc');
-					rkey_alt python:'desc' if rkey=='asc' else 'asc';
-					obs python: indexes.manage_get_sortedObjects(sortkey=skey, revkey=rkey);">
-				<tal:itemslist condition="obs">
-					<table class="table table-striped table-hover table-sm objectItems">
-						<thead class="thead-light" tal:attributes="class python:'thead-light sorted_%s'%(request.get('rkey',''))">
-							<tr>
-								<th scope="col" class="zmi-object-check text-right text-nowrap">
-									<input type="checkbox" id="checkAll" onclick="checkbox_all();" />
-								</th>
-								<th scope="col" class="zmi-object-id">
-									<a title="Sort Ascending by Name"
-										href="?skey=id&rkey=asc"
-										tal:attributes="
-											title python:'Sort %s by Name'%( rkey_alt.upper() );
-											href python:'?skey=id&rkey=%s'%( rkey_alt );
-											class python:request.get('skey',None)=='id' and 'zmi-sort_key' or None;">
-										Name
-										<i class="fa fa-sort"></i>
-									</a>
-								</th>
-								<th scope="col" class="zmi-object-indextype text-nowrap">
-									<a title="Sort Ascending by index type"
-										href="?skey=meta_type&rkey=asc"
-										tal:attributes="
-											title python:'Sort %s by index type'%( rkey_alt.upper() );
-											href python:'?skey=meta_type&rkey=%s'%( rkey_alt );
-											class python:request.get('skey',None)=='meta_type' and 'zmi-sort_key' or None;">
-										Index type
-										<i class="fa fa-sort"></i>
-									</a>
-								</th>
-								<th scope="col" class="zmi-object-size hidden-xs text-nowrap">
-									<a title="Sort Ascending by indexed values"
-										href="?skey=indexSize&rkey=asc"
-										tal:attributes="
-											title python:'Sort %s by indexed values'%( rkey_alt.upper() );
-											href python:'?skey=indexSize&rkey=%s'%( rkey_alt );
-											class python:request.get('skey',None)=='indexSize' and 'zmi-sort_key' or None;">
-										# distinct values
-										<i class="fa fa-sort"></i>
-									</a>
-								</th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr tal:repeat="ob_dict obs">
-								<tal:obj define="ob nocall:ob_dict/obj">
-									<td class="zmi-object-check text-right" onclick="$(this).children('input').trigger('click');">
-										<input type="checkbox" class="checkbox-list-item" name="ids:list" tal:attributes="value ob_dict/id" 
-										onclick="event.stopPropagation();select_objectitem($(this));" />
-									</td>
-									<td>
-										<a tal:attributes="href string:Indexes/${ob_dict/quoted_id}/manage_workspace" tal:content="ob_dict/id"></a>
-										<small tal:define="sourcenames ob/getIndexSourceNames"
-										tal:condition="python: len(sourcenames) != 1 or sourcenames[0] != ob_dict['id']"
-										tal:on-error="string:(${ob_dict/title|nothing})">
-											(indexed attributes: <span tal:replace="python: ', '.join(sourcenames)"/>)   	
-										</small>
-									</td>
-									<td class="text-left" tal:content="ob/meta_type"></td>
-									<td class="text-left zmi-object-size hidden-xs"
-											tal:content="ob/indexSize|string:n/a">
-									</td>
-								</tal:obj>
-							</tr>
-						</tbody>
-					</table>
+    <p class="form-help">
+        This list defines what indexes the Catalog will contain. When objects
+        get cataloged, the values of any attributes which match
+        an index in this list will get indexed. If you add indexes to a Catalog
+        which contains indexed objects, you MUST at the least re-index your newly
+        added index. You may want to update the whole Catalog.
+    </p>
+    <tal:indexes define="indexes context/Indexes">
+        <tal:add define="filtered_meta_types context/availableIndexes">
+            <form tal:attributes="action context/absolute_url" method="get">
+                <div class="form-group mt-4 mb-4">
+                    <div class="input-group">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text">Add <span class="d-sm-block d-none">&nbsp;new&nbsp;</span> Index:</span>
+                        </div>
+                            <tal:indexlist condition="python:len(filtered_meta_types) > 1">
+                                <select id="addindex" class="form-control" name=":action"
+                                    onChange=""
+                                    tal:attributes="onChange string:location.href='${request/URL1}/'+this.options[this.selectedIndex].value">
+                                    <option value="manage_workspace" disabled>Select type to add...</option>
+                                    <tal:types repeat="indextype filtered_meta_types">
+                                        <option tal:attributes="value indextype/action"
+                                            tal:content="indextype/name"></option>
+                                    </tal:types>
+                                </select>
+                            </tal:indexlist>
+                            <div class="input-group-append">
+                                <input class="btn btn-primary" type="submit" name="submit" value="Add" />
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </tal:add>
+        <form tal:attributes="action string:${request/URL1}/" name="objectItems" method="post">
+            <tal:items define="
+                    skey python:request.get('skey','id');
+                    rkey python:request.get('rkey','asc');
+                    rkey_alt python:'desc' if rkey=='asc' else 'asc';
+                    obs python: indexes.manage_get_sortedObjects(sortkey=skey, revkey=rkey);">
+                <tal:itemslist condition="obs">
+                    <table class="table table-striped table-hover table-sm objectItems">
+                        <thead class="thead-light" tal:attributes="class python:'thead-light sorted_%s'%(request.get('rkey',''))">
+                            <tr>
+                                <th scope="col" class="zmi-object-check text-right text-nowrap">
+                                    <input type="checkbox" id="checkAll" onclick="checkbox_all();" />
+                                </th>
+                                <th scope="col" class="zmi-object-id">
+                                    <a title="Sort Ascending by Name"
+                                        href="?skey=id&rkey=asc"
+                                        tal:attributes="
+                                            title python:'Sort %s by Name'%( rkey_alt.upper() );
+                                            href python:'?skey=id&rkey=%s'%( rkey_alt );
+                                            class python:request.get('skey',None)=='id' and 'zmi-sort_key' or None;">
+                                        Name
+                                        <i class="fa fa-sort"></i>
+                                    </a>
+                                </th>
+                                <th scope="col" class="zmi-object-indextype text-nowrap">
+                                    <a title="Sort Ascending by index type"
+                                        href="?skey=meta_type&rkey=asc"
+                                        tal:attributes="
+                                            title python:'Sort %s by index type'%( rkey_alt.upper() );
+                                            href python:'?skey=meta_type&rkey=%s'%( rkey_alt );
+                                            class python:request.get('skey',None)=='meta_type' and 'zmi-sort_key' or None;">
+                                        Index type
+                                        <i class="fa fa-sort"></i>
+                                    </a>
+                                </th>
+                                <th scope="col" class="zmi-object-size hidden-xs text-nowrap">
+                                    <a title="Sort Ascending by indexed values"
+                                        href="?skey=indexSize&rkey=asc"
+                                        tal:attributes="
+                                            title python:'Sort %s by indexed values'%( rkey_alt.upper() );
+                                            href python:'?skey=indexSize&rkey=%s'%( rkey_alt );
+                                            class python:request.get('skey',None)=='indexSize' and 'zmi-sort_key' or None;">
+                                        # distinct values
+                                        <i class="fa fa-sort"></i>
+                                    </a>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr tal:repeat="ob_dict obs">
+                                <tal:obj define="ob nocall:ob_dict/obj">
+                                    <td class="zmi-object-check text-right" onclick="$(this).children('input').trigger('click');">
+                                        <input type="checkbox" class="checkbox-list-item" name="ids:list" tal:attributes="value ob_dict/id" 
+                                        onclick="event.stopPropagation();select_objectitem($(this));" />
+                                    </td>
+                                    <td>
+                                        <a tal:attributes="href string:Indexes/${ob_dict/quoted_id}/manage_workspace" tal:content="ob_dict/id"></a>
+                                        <small tal:define="sourcenames ob/getIndexSourceNames"
+                                        tal:condition="python: len(sourcenames) != 1 or sourcenames[0] != ob_dict['id']"
+                                        tal:on-error="string:(${ob_dict/title|nothing})">
+                                            (indexed attributes: <span tal:replace="python: ', '.join(sourcenames)"/>)       
+                                        </small>
+                                    </td>
+                                    <td class="text-left" tal:content="ob/meta_type"></td>
+                                    <td class="text-left zmi-object-size hidden-xs"
+                                            tal:content="ob/indexSize|string:n/a">
+                                    </td>
+                                </tal:obj>
+                            </tr>
+                        </tbody>
+                    </table>
 
-					<div class="zmi-controls">
-						<input class="btn btn-primary" type="submit" name="manage_delIndex:method" value="Remove index" />
-						<input class="btn btn-primary" type="submit" name="manage_reindexIndex:method" value="Reindex" />
-						<input class="btn btn-primary" type="submit" name="manage_clearIndex:method" value="Clear index" />
-					</div>
+                    <div class="zmi-controls">
+                        <input class="btn btn-primary" type="submit" name="manage_delIndex:method" value="Remove index" />
+                        <input class="btn btn-primary" type="submit" name="manage_reindexIndex:method" value="Reindex" />
+                        <input class="btn btn-primary" type="submit" name="manage_clearIndex:method" value="Clear index" />
+                    </div>
 
-				</tal:itemslist>
+                </tal:itemslist>
 
-				<tal:noitems condition="not: obs">
-					<div class="alert alert-info">There are currently no indexes</div>
-				</tal:noitems>
+                <tal:noitems condition="not: obs">
+                    <div class="alert alert-info">There are currently no indexes</div>
+                </tal:noitems>
 
-			</tal:items>
-		</form>
-	</tal:indexes>
+            </tal:items>
+        </form>
+    </tal:indexes>
 </main>
 
 <script>
 //<!--
-	// +++++++++++++++++++++++++++
-	// Item  Selection
-	// +++++++++++++++++++++++++++
-	function checkbox_all() {
-	var checkboxes = document.getElementsByClassName('checkbox-list-item');
-	// Toggle Highlighting CSS-Class
-	if (document.getElementById('checkAll').checked) {
-		$('table.objectItems tbody tr').addClass('checked');
-	} else {
-		$('table.objectItems tbody tr').removeClass('checked');
-	};
-	// Set Checkbox like checkAll-Box
-	for (i = 0; i < checkboxes.length; i++) {
-		checkboxes[i].checked = document.getElementById('checkAll').checked;
-	}
-	};
+    // +++++++++++++++++++++++++++
+    // Item  Selection
+    // +++++++++++++++++++++++++++
+    function checkbox_all() {
+    var checkboxes = document.getElementsByClassName('checkbox-list-item');
+    // Toggle Highlighting CSS-Class
+    if (document.getElementById('checkAll').checked) {
+        $('table.objectItems tbody tr').addClass('checked');
+    } else {
+        $('table.objectItems tbody tr').removeClass('checked');
+    };
+    // Set Checkbox like checkAll-Box
+    for (i = 0; i < checkboxes.length; i++) {
+        checkboxes[i].checked = document.getElementById('checkAll').checked;
+    }
+    };
 //-->
 </script>
 

--- a/src/Products/ZCatalog/zpt/catalogIndexes.zpt
+++ b/src/Products/ZCatalog/zpt/catalogIndexes.zpt
@@ -35,116 +35,117 @@
 						</div>
 					</div>
 				</div>
-
 			</form>
 		</tal:add>
 		<form tal:attributes="action string:${request/URL1}/" name="objectItems" method="post">
 			<tal:items define="
-                    skey python:request.get('skey','id');
-                    rkey python:request.get('rkey','asc');
-                    rkey_alt python:'desc' if rkey=='asc' else 'asc';
+					skey python:request.get('skey','id');
+					rkey python:request.get('rkey','asc');
+					rkey_alt python:'desc' if rkey=='asc' else 'asc';
 					obs python: indexes.manage_get_sortedObjects(sortkey=skey, revkey=rkey);">
-			  <tal:itemslist condition="obs">
-				<table class="table table-striped table-hover table-sm objectItems">
-			        <thead class="thead-light" tal:attributes="class python:'thead-light sorted_%s'%(request.get('rkey',''))">
-			          <tr>
-			            <th scope="col" class="zmi-object-check text-right">
-			              <input type="checkbox" id="checkAll" onclick="checkbox_all();" />
-			            </th>
+				<tal:itemslist condition="obs">
+					<table class="table table-striped table-hover table-sm objectItems">
+						<thead class="thead-light" tal:attributes="class python:'thead-light sorted_%s'%(request.get('rkey',''))">
+							<tr>
+								<th scope="col" class="zmi-object-check text-right text-nowrap">
+									<input type="checkbox" id="checkAll" onclick="checkbox_all();" />
+								</th>
+								<th scope="col" class="zmi-object-id">
+									<a title="Sort Ascending by Name"
+										href="?skey=id&rkey=asc"
+										tal:attributes="
+											title python:'Sort %s by Name'%( rkey_alt.upper() );
+											href python:'?skey=id&rkey=%s'%( rkey_alt );
+											class python:request.get('skey',None)=='id' and 'zmi-sort_key' or None;">
+										Name
+										<i class="fa fa-sort"></i>
+									</a>
+								</th>
+								<th scope="col" class="zmi-object-indextype text-nowrap">
+									<a title="Sort Ascending by index type"
+										href="?skey=meta_type&rkey=asc"
+										tal:attributes="
+											title python:'Sort %s by index type'%( rkey_alt.upper() );
+											href python:'?skey=meta_type&rkey=%s'%( rkey_alt );
+											class python:request.get('skey',None)=='meta_type' and 'zmi-sort_key' or None;">
+										Index type
+										<i class="fa fa-sort"></i>
+									</a>
+								</th>
+								<th scope="col" class="zmi-object-size hidden-xs text-nowrap">
+									<a title="Sort Ascending by indexed values"
+										href="?skey=indexSize&rkey=asc"
+										tal:attributes="
+											title python:'Sort %s by indexed values'%( rkey_alt.upper() );
+											href python:'?skey=indexSize&rkey=%s'%( rkey_alt );
+											class python:request.get('skey',None)=='indexSize' and 'zmi-sort_key' or None;">
+										# distinct values
+										<i class="fa fa-sort"></i>
+									</a>
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr tal:repeat="ob_dict obs">
+								<tal:obj define="ob nocall:ob_dict/obj">
+									<td class="zmi-object-check text-right" onclick="$(this).children('input').trigger('click');">
+										<input type="checkbox" class="checkbox-list-item" name="ids:list" tal:attributes="value ob_dict/id" 
+										onclick="event.stopPropagation();select_objectitem($(this));" />
+									</td>
+									<td>
+										<a tal:attributes="href string:Indexes/${ob_dict/quoted_id}/manage_workspace" tal:content="ob_dict/id"></a>
+										<small tal:define="sourcenames ob/getIndexSourceNames"
+										tal:condition="python: len(sourcenames) != 1 or sourcenames[0] != ob_dict['id']"
+										tal:on-error="string:(${ob_dict/title|nothing})">
+											(indexed attributes: <span tal:replace="python: ', '.join(sourcenames)"/>)   	
+										</small>
+									</td>
+									<td class="text-left" tal:content="ob/meta_type"></td>
+									<td class="text-left zmi-object-size hidden-xs"
+											tal:content="ob/indexSize|string:n/a">
+									</td>
+								</tal:obj>
+							</tr>
+						</tbody>
+					</table>
 
-			            <th scope="col" class="zmi-object-id">
-			              <a title="Sort Ascending by Name"
-			                 href="?skey=id&rkey=asc"
-			                 tal:attributes="title python:'Sort %s by Name'%( rkey_alt.upper() );
-			                                 href python:'?skey=id&rkey=%s'%( rkey_alt );
-			                                 class python:request.get('skey',None)=='id' and 'zmi-sort_key' or None;
-			                                ">
-			                Name
-			                <i class="fa fa-sort"></i>
-			              </a>
-			            </th>
-
-			            <th scope="col" class="zmi-object-indextype">
-			              <a title="Sort Ascending by index type"
-			                 href="?skey=meta_type&rkey=asc"
-			                 tal:attributes="title python:'Sort %s by index type'%( rkey_alt.upper() );
-			                                 href python:'?skey=meta_type&rkey=%s'%( rkey_alt );
-			                                 class python:request.get('skey',None)=='meta_type' and 'zmi-sort_key' or None;
-			                                ">
-			                Index type
-			                <i class="fa fa-sort"></i>
-			              </a>
-			            </th>
-
-			            <th scope="col" class="zmi-object-size hidden-xs">
-			              <a title="Sort Ascending by indexed values"
-			                 href="?skey=indexSize&rkey=asc"
-			                 tal:attributes="title python:'Sort %s by indexed values'%( rkey_alt.upper() );
-			                                 href python:'?skey=indexSize&rkey=%s'%( rkey_alt );
-			                                 class python:request.get('skey',None)=='indexSize' and 'zmi-sort_key' or None;
-			                                ">
-			                # distinct values
-			                <i class="fa fa-sort"></i>
-			              </a>
-			            </th>
-			            
-			          </tr>
-			        </thead>
-					<tbody>
-						<tr tal:repeat="ob_dict obs">
-				            <tal:obj define="ob nocall:ob_dict/obj">
-				              <td class="zmi-object-check text-right" onclick="$(this).children('input').trigger('click');">
-				                <input type="checkbox" class="checkbox-list-item" name="ids:list" tal:attributes="value ob_dict/id" 
-				                  onclick="event.stopPropagation();select_objectitem($(this));" />
-				              </td>
-				              <td>
-				              	<a tal:attributes="href string:Indexes/${ob_dict/quoted_id}/manage_workspace" tal:content="ob_dict/id"></a>
-				              	<small tal:define="sourcenames ob/getIndexSourceNames"
-				              	   tal:condition="python: len(sourcenames) != 1 or sourcenames[0] != ob_dict['id']"
-				              	   tal:on-error="string:(${ob_dict/title|nothing})">
-				              		(indexed attributes: <span tal:replace="python: ', '.join(sourcenames)"/>)   	
-				              	</small>
-				              </td>
-				              <td class="text-left" tal:content="ob/meta_type"></td>
-				              <td class="text-left zmi-object-size hidden-xs"
-				              		tal:content="ob/indexSize|string:n/a">
-				              </td>
-				            </tal:obj>
-				          </tr>
-					</tbody>
-				</table>
-
-				<div class="zmi-controls">
-					<input class="btn btn-primary" type="submit" name="manage_delIndex:method" value="Remove index" />
-					<input class="btn btn-primary" type="submit" name="manage_reindexIndex:method" value="Reindex" />
-					<input class="btn btn-primary" type="submit" name="manage_clearIndex:method" value="Clear index" />
-				</div>
+					<div class="zmi-controls">
+						<input class="btn btn-primary" type="submit" name="manage_delIndex:method" value="Remove index" />
+						<input class="btn btn-primary" type="submit" name="manage_reindexIndex:method" value="Reindex" />
+						<input class="btn btn-primary" type="submit" name="manage_clearIndex:method" value="Clear index" />
+					</div>
 
 				</tal:itemslist>
+
 				<tal:noitems condition="not: obs">
 					<div class="alert alert-info">There are currently no indexes</div>
 				</tal:noitems>
+
 			</tal:items>
 		</form>
 	</tal:indexes>
 </main>
+
 <script>
-  // +++++++++++++++++++++++++++
-  // Item  Selection
-  // +++++++++++++++++++++++++++
-  function checkbox_all() {
-    var checkboxes = document.getElementsByClassName('checkbox-list-item');
-    // Toggle Highlighting CSS-Class
-    if (document.getElementById('checkAll').checked) {
-      $('table.objectItems tbody tr').addClass('checked');
-    } else {
-      $('table.objectItems tbody tr').removeClass('checked');
-    };
-    // Set Checkbox like checkAll-Box
-    for (i = 0; i < checkboxes.length; i++) {
-      checkboxes[i].checked = document.getElementById('checkAll').checked;
-    }
-  };
+//<!--
+	// +++++++++++++++++++++++++++
+	// Item  Selection
+	// +++++++++++++++++++++++++++
+	function checkbox_all() {
+	var checkboxes = document.getElementsByClassName('checkbox-list-item');
+	// Toggle Highlighting CSS-Class
+	if (document.getElementById('checkAll').checked) {
+		$('table.objectItems tbody tr').addClass('checked');
+	} else {
+		$('table.objectItems tbody tr').removeClass('checked');
+	};
+	// Set Checkbox like checkAll-Box
+	for (i = 0; i < checkboxes.length; i++) {
+		checkboxes[i].checked = document.getElementById('checkAll').checked;
+	}
+	};
+//-->
 </script>
+
 <tal:footer replace="structure here/manage_page_footer" />
 


### PR DESCRIPTION
Hi @dataflake ,
I fitted ZCatalog-ZMI pages, which did not contain all the necessary CSS classes needed for a  nice Zope look. Following tabs are refreshed now:

- Catalog
- Query Report 
- Query Plan

_Screen Image: Left: former ZMI, right: refreshed ZMI_
![ZCatalog_ZMI](https://user-images.githubusercontent.com/29705216/150558723-27f22df3-573a-4715-aaf1-17bec99ba241.gif)

A small side effect to be discussed:
Historically the Zope default CSS _zmi.base.css_ compensates some super-bad layout effects of the non-bootrappyfied ZCatalog ZMI. These 3 elements are not needed anymore for Zope: https://github.com/zopefoundation/Zope/blob/b72715cf01cce1a49b59198047113f29f89037c5/src/zmi/styles/resources/zmi_base.css#L891-L905
But many installations may not use the latest ZCatalog, so I added a CSS snippet into 
ZCatalog/dtml/catalogView.dtml Line134+ for neutralizing the upper Zope CSS dealing with the former non-conformance to a strict styling.  Please tell me, if you prefer removing it both from Zope an ZCatalog. 