### PR TITLE
Avoid error in search when the parameter received by IndexQuery is a record

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 6.2 (unreleased)
 ----------------
 
+- Avoid error in search when the parameter received by ``IndexQuery`` is a ``record``.
+  (`plone/Products.CMFPlone#3007 <https://github.com/plone/Products.CMFPlone/issues/3007>`_)
+
 - Refactored and improved ZMI templates
   (`#128 <https://github.com/zopefoundation/Products.ZCatalog/pull/128>`_)
 

--- a/src/Products/ZCatalog/query.py
+++ b/src/Products/ZCatalog/query.py
@@ -11,6 +11,9 @@
 #
 ##############################################################################
 
+from ZPublisher.HTTPRequest import record
+
+
 _marker = object()
 
 
@@ -65,7 +68,7 @@ class IndexQuery(object):
         param = request[iid]
         keys = None
 
-        if isinstance(param, dict):
+        if isinstance(param, (dict, record)):
             # query is a dictionary containing all parameters
             query = param.get('query', ())
             if isinstance(query, (tuple, list)):

--- a/src/Products/ZCatalog/tests/test_query.py
+++ b/src/Products/ZCatalog/tests/test_query.py
@@ -13,6 +13,8 @@
 
 import unittest
 
+from ZPublisher.HTTPRequest import record
+
 
 class TestIndexQuery(unittest.TestCase):
 
@@ -109,3 +111,14 @@ class TestIndexQuery(unittest.TestCase):
         with self.assertRaises(ValueError):
             self._makeOne(
                 request, 'extra_path', ('query', 'operator'), ('or', 'and'))
+
+    def test_param_record(self):
+        path = record()
+        path.query = ['foo']
+        path.level = 0
+        path.operator = 'and'
+        request = {'path': path}
+        parser = self._makeOne(request, 'path', ('query', 'level', 'operator'))
+        self.assertEqual(parser.get('keys'), ['foo'])
+        self.assertEqual(parser.get('level'), 0)
+        self.assertEqual(parser.get('operator'), 'and')


### PR DESCRIPTION
When using record notation in URL parameters, for example:

http://localhost:8080/Plone/@@search?end.query:record:list:date=2022-2-2+00%3A00%3A00&end.range:record=min

On the Zope side, this parameter becomes a `ZPublisher.HTTPRequest.record`, not a dictionary.

However, `IndexQuery` only expected the parameter to be a dictionary. When the parameter is a record and it is not considered when extracting the `query` key, the error occurs:

```
TypeError: unailshable type: 'record'
```
in search.

Now we consider that the parameter can be a record as well.

Fixes plone/Products.CMFPlone#3007