### PR TITLE
Avoid error in search when the parameter received by IndexQuery is a record - 5.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Avoid error in search when the parameter received by ``IndexQuery`` is a ``record``.
+  (`plone/Products.CMFPlone#3007 <https://github.com/plone/Products.CMFPlone/issues/3007>`_)
 
 
 5.3 (2021-01-29)

--- a/src/Products/ZCatalog/query.py
+++ b/src/Products/ZCatalog/query.py
@@ -11,6 +11,9 @@
 #
 ##############################################################################
 
+from ZPublisher.HTTPRequest import record
+
+
 _marker = object()
 
 
@@ -65,7 +68,7 @@ class IndexQuery(object):
         param = request[iid]
         keys = None
 
-        if isinstance(param, dict):
+        if isinstance(param, (dict, record)):
             # query is a dictionary containing all parameters
             query = param.get('query', ())
             if isinstance(query, (tuple, list)):

--- a/src/Products/ZCatalog/tests/test_query.py
+++ b/src/Products/ZCatalog/tests/test_query.py
@@ -13,6 +13,8 @@
 
 import unittest
 
+from ZPublisher.HTTPRequest import record
+
 
 class TestIndexQuery(unittest.TestCase):
 
@@ -98,3 +100,14 @@ class TestIndexQuery(unittest.TestCase):
                           self._makeOne,
                           request, 'path',
                           ('query', 'operator'))
+
+    def test_param_record(self):
+        path = record()
+        path.query = ['foo']
+        path.level = 0
+        path.operator = 'and'
+        request = {'path': path}
+        parser = self._makeOne(request, 'path', ('query', 'level', 'operator'))
+        self.assertEqual(parser.get('keys'), ['foo'])
+        self.assertEqual(parser.get('level'), 0)
+        self.assertEqual(parser.get('operator'), 'and')


### PR DESCRIPTION
This is a cherry-pick from #129  to the `5.x` branch.

Fixes https://github.com/plone/Products.CMFPlone/issues/3007