### PR TITLE
Fix catalog plan for performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 6.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Improve performance stability. Fix catalog plan for unused index in a query.
+  (`#138 <https://github.com/zopefoundation/Products.ZCatalog/pull/138>`_)
 
 
 6.2 (2022-04-08)

--- a/src/Products/ZCatalog/tests/test_plan.py
+++ b/src/Products/ZCatalog/tests/test_plan.py
@@ -27,6 +27,7 @@ from Products.PluginIndexes.KeywordIndex.KeywordIndex import KeywordIndex
 from Products.PluginIndexes.PathIndex.PathIndex import PathIndex
 from Products.PluginIndexes.UUIDIndex.UUIDIndex import UUIDIndex
 from Products.ZCatalog.Catalog import Catalog
+from Products.ZCatalog.plan import MAX_DISTINCT_VALUES
 from Products.ZCatalog.ZCatalog import ZCatalog
 
 
@@ -223,6 +224,87 @@ class TestCatalogPlan(cleanup.CleanUp, unittest.TestCase):
         plan_str = zcat.getCatalogPlan()
         self.assertIn('queryplan = {', plan_str)
         self.assertIn('index1', plan_str)
+
+    def test_getCatalogPlan_partial(self):
+        zcat = ZCatalog("catalog")
+        cat = zcat._catalog
+
+        class SlowFieldIndex(FieldIndex):
+            def query_index(self, record, resultset=None):
+                time.sleep(0.1)
+                return super(SlowFieldIndex, self).query_index(
+                    record, resultset)
+
+        class SlowerDateRangeIndex(DateRangeIndex):
+            def query_index(self, record, resultset=None):
+                time.sleep(0.2)
+                return super(SlowerDateRangeIndex, self).query_index(
+                    record, resultset)
+
+        cat.addIndex("num", SlowFieldIndex("num"))
+        cat.addIndex("numbers", KeywordIndex("numbers"))
+        cat.addIndex("path", PathIndex("getPhysicalPath"))
+        cat.addIndex("date", SlowerDateRangeIndex("date", "start", "end"))
+
+        for i in range(MAX_DISTINCT_VALUES * 2):
+            obj = Dummy(i)
+            zcat.catalog_object(obj, str(i))
+
+        query1 = {"num": 2, "numbers": 3, "date": "2013-07-03"}
+        # query with no result, because of `numbers`
+        query2 = {"num": 2, "numbers": -1, "date": "2013-07-03"}
+
+        # without a plan index are orderd alphabetically by default
+        self.assertEqual(zcat._catalog.getCatalogPlan(query1).plan(), None)
+        self.assertEqual(
+            cat._sorted_search_indexes(query1),
+            ["date", "num", "numbers"]
+        )
+
+        self.assertEqual([b.getPath() for b in zcat.search(query1)], ["2"])
+        self.assertRegex(
+            zcat.getCatalogPlan(),
+            r"(?ms).*'date':\s*\([0-9\.]+, [0-9\.]+, True\)"
+        )
+        self.assertRegex(
+            zcat.getCatalogPlan(),
+            r"(?ms).*'num':\s*\([0-9\.]+, [0-9\.]+, True\)"
+        )
+        self.assertRegex(
+            zcat.getCatalogPlan(),
+            r"(?ms).*'numbers':\s*\([0-9\.]+, [0-9\.]+, True\)"
+        )
+
+        # after first search field are orderd by speed
+        self.assertEqual(
+            cat.getCatalogPlan(query2).plan(), ["numbers", "num", "date"])
+
+        self.assertEqual([b.getPath() for b in zcat.search(query2)], [])
+
+        # `date', `num`, and `numbers` are all involved to filter the
+        #  results(limit flag) despite in the last query search whitin
+        #  `num` and `date` wasn't done
+        self.assertRegex(
+            zcat.getCatalogPlan(),
+            r"(?ms).*'date':\s*\([0-9\.]+, [0-9\.]+, True\)"
+        )
+        self.assertRegex(
+            zcat.getCatalogPlan(),
+            r"(?ms).*'num':\s*\([0-9\.]+, [0-9\.]+, True\)"
+        )
+        self.assertRegex(
+            zcat.getCatalogPlan(),
+            r"(?ms).*'numbers':\s*\([0-9\.]+, [0-9\.]+, True\)"
+        )
+        self.assertEqual(
+            cat.getCatalogPlan(query2).plan(), ["numbers", "num", "date"]
+        )
+
+        # search again doesn't change the index order
+        self.assertEqual([b.getPath() for b in zcat.search(query1)], ["2"])
+        self.assertEqual(
+            cat.getCatalogPlan(query2).plan(), ["numbers", "num", "date"]
+        )
 
     def test_plan_empty(self):
         plan = self._makeOne()

--- a/src/Products/ZCatalog/tests/test_plan.py
+++ b/src/Products/ZCatalog/tests/test_plan.py
@@ -186,6 +186,12 @@ class TestReports(unittest.TestCase):
 
 class TestCatalogPlan(cleanup.CleanUp, unittest.TestCase):
 
+    def assertRegex(self, *args, **kwargs):
+        if six.PY2:
+            return self.assertRegexpMatches(*args, **kwargs)
+        else:
+            return super(TestCatalogPlan, self).assertRegex(*args, **kwargs)
+
     def setUp(self):
         cleanup.CleanUp.setUp(self)
         self.cat = Catalog('catalog')
@@ -263,18 +269,15 @@ class TestCatalogPlan(cleanup.CleanUp, unittest.TestCase):
         )
 
         self.assertEqual([b.getPath() for b in zcat.search(query1)], ["2"])
-        six.assertRegex(
-            self,
+        self.assertRegex(
             zcat.getCatalogPlan(),
             r"(?ms).*'date':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )
-        six.assertRegex(
-            self,
+        self.assertRegex(
             zcat.getCatalogPlan(),
             r"(?ms).*'num':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )
-        six.assertRegex(
-            self,
+        self.assertRegex(
             zcat.getCatalogPlan(),
             r"(?ms).*'numbers':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )
@@ -288,18 +291,15 @@ class TestCatalogPlan(cleanup.CleanUp, unittest.TestCase):
         # `date', `num`, and `numbers` are all involved to filter the
         #  results(limit flag) despite in the last query search whitin
         #  `num` and `date` wasn't done
-        six.assertRegex(
-            self,
+        self.assertRegex(
             zcat.getCatalogPlan(),
             r"(?ms).*'date':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )
-        six.assertRegex(
-            self,
+        self.assertRegex(
             zcat.getCatalogPlan(),
             r"(?ms).*'num':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )
-        six.assertRegex(
-            self,
+        self.assertRegex(
             zcat.getCatalogPlan(),
             r"(?ms).*'numbers':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )

--- a/src/Products/ZCatalog/tests/test_plan.py
+++ b/src/Products/ZCatalog/tests/test_plan.py
@@ -16,6 +16,7 @@ import os.path
 import time
 import unittest
 
+import six
 from six.moves._thread import LockType
 
 from zope.testing import cleanup
@@ -262,15 +263,18 @@ class TestCatalogPlan(cleanup.CleanUp, unittest.TestCase):
         )
 
         self.assertEqual([b.getPath() for b in zcat.search(query1)], ["2"])
-        self.assertRegex(
+        six.assertRegex(
+            self,
             zcat.getCatalogPlan(),
             r"(?ms).*'date':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )
-        self.assertRegex(
+        six.assertRegex(
+            self,
             zcat.getCatalogPlan(),
             r"(?ms).*'num':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )
-        self.assertRegex(
+        six.assertRegex(
+            self,
             zcat.getCatalogPlan(),
             r"(?ms).*'numbers':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )
@@ -284,15 +288,18 @@ class TestCatalogPlan(cleanup.CleanUp, unittest.TestCase):
         # `date', `num`, and `numbers` are all involved to filter the
         #  results(limit flag) despite in the last query search whitin
         #  `num` and `date` wasn't done
-        self.assertRegex(
+        six.assertRegex(
+            self,
             zcat.getCatalogPlan(),
             r"(?ms).*'date':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )
-        self.assertRegex(
+        six.assertRegex(
+            self,
             zcat.getCatalogPlan(),
             r"(?ms).*'num':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )
-        self.assertRegex(
+        six.assertRegex(
+            self,
             zcat.getCatalogPlan(),
             r"(?ms).*'numbers':\s*\([0-9\.]+, [0-9\.]+, True\)"
         )


### PR DESCRIPTION
In a large Plone website with a ZCatalog containing more than 400K objects, we found poor performance in catalog queries. This is probably not surprising.

But upon further analysis, I saw that many long-running queries were about searching on `effectiveRange` (type `DateRangeIndex`) https://github.com/zopefoundation/Products.ZCatalog/blob/5a3272f5e5f0429910ecdc91bf9e2702bc276e7d/src/Products/PluginIndexes/DateRangeIndex/DateRangeIndex.py#L282-L285

The problem is that `DateRangIndex` (but also other indexes) behaves very differently if it is called as first (with `resultset` equal to None) or not. The main goal of the catalog plan is to solve the above problem by ordering the queries to the indexes from fastest to slowest and executing the queries in that order. So, I was surprised that sometimes the `effectiveRange` was executed first, resulting in a large performance penalty.

This is what I hypothesized: suppose we have a search with `path` (type `PathIndex`) and `effectiveRange` (type `DateRangeIndex`). In the first time, without a plan, the indexes are sorted alphabetically, so `effectiveRange` is the first one executed. In subsequent searches, the plan, correctly, sorts the indexes and the `path` query is executed first, followed by the slower `effectiveRange`.

But if, at some point, the `path` query returns no results, `effectiveRange` will not be executed https://github.com/zopefoundation/Products.ZCatalog/blob/5a3272f5e5f0429910ecdc91bf9e2702bc276e7d/src/Products/ZCatalog/Catalog.py#L638-L639 and in the query plan, for an index that does not have a benchmark in the current search, the new benchmark saved will be (0, 0, False) (i.e., 0s duration, 0 hits and the last boolean means that the index does not filter results) https://github.com/zopefoundation/Products.ZCatalog/blob/5a3272f5e5f0429910ecdc91bf9e2702bc276e7d/src/Products/ZCatalog/plan.py#L306-L307 With this benchmark `effectiveRange` becomes the first index used in the next search, resulting in poor performance.

In the proposed implementation, I changed this last behavior: if the search was not performed for an index, the benchmark used remains the previous one, if it exists.

I think there is still more room for improvement in the code, studying more sophisticated query planners. But, of course, adding these elements will also add more complexity.

In the meantime, in all the real-world situations where I have tested the implementation proposed here, I have experienced a terrific improvement in performance.

p.s. For easily try the code here, I have just released a package https://pypi.org/project/experimental.catalogplan/ with a monkey patch that implements the same changes proposed here.