### PR TITLE
Fix catalog plan for not query

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changelog
 - Improve performance stability. Fix catalog plan for unused index in a query.
   (`#138 <https://github.com/zopefoundation/Products.ZCatalog/pull/138>`_)
 
+- Improve performance stability. Fix catalog plan for not query.
+  (`#139 <https://github.com/zopefoundation/Products.ZCatalog/pull/139>`_)
+
 
 6.2 (2022-04-08)
 ----------------

--- a/src/Products/ZCatalog/plan.py
+++ b/src/Products/ZCatalog/plan.py
@@ -249,7 +249,7 @@ class CatalogPlan(object):
             if isinstance(query.get(name), dict) and "not" in query[name]
         ]
         if notkeys:
-            key = [name for name in keys if name not in notkeys]
+            key = [name for name in key if name not in notkeys]
             key.extend([(name, "not") for name in notkeys])
         # Workaround: Python 2.x accepted different types as sort key
         # for the sorted builtin. Python 3 only sorts on identical types.

--- a/src/Products/ZCatalog/plan.py
+++ b/src/Products/ZCatalog/plan.py
@@ -244,7 +244,13 @@ class CatalogPlan(object):
                 # repr() is an easy way to do this without imposing
                 # restrictions on the types of values.
                 key.append((name, repr(v)))
-
+        notkeys = [
+            name for name in key
+            if isinstance(query.get(name), dict) and "not" in query[name]
+        ]
+        if notkeys:
+            key = [name for name in keys if name not in notkeys]
+            key.extend([(name, "not") for name in notkeys])
         # Workaround: Python 2.x accepted different types as sort key
         # for the sorted builtin. Python 3 only sorts on identical types.
         tuple_keys = set(key) - set(


### PR DESCRIPTION
The `not` queries produce the same key as the normal queries in the catalog plan, this is a problem because the `not` queries could generally be slower.

Before this PR, the queries `{'UID': '1', path: '/a'}` and `{'UID': {'not': '1'}, path: '/a'}` share the same plan, with the key `('UID', 'path')`, after they will have two distinct plan with the keys `('UID', 'path')` and `(('UID', 'not'), 'path')`.
