### PR TITLE
Make test_getCatalogPlan_partial test more stable.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - ubuntu
+        - ["ubuntu", "ubuntu-20.04"]
         config:
         # [Python version, tox env]
         - ["3.9",   "lint"]
@@ -28,18 +28,20 @@ jobs:
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]
+        - ["3.11",  "py311"]
         - ["3.9",   "coverage"]
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os[1] }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os:
         - ["ubuntu", "ubuntu-20.04"]
+        - ["macos", "macos-latest"]
         config:
         # [Python version, tox env]
         - ["3.9",   "lint"]
@@ -30,10 +31,16 @@ jobs:
         - ["3.10",  "py310"]
         - ["3.11",  "py311"]
         - ["3.9",   "coverage"]
+        exclude:
+          - { os: ["macos", "macos-latest"], config: ["3.9",   "lint"] }
+          - { os: ["macos", "macos-latest"], config: ["3.9",   "coverage"] }
+          # macOS/Python 3.11 is set up for universal2 architecture
+          # which causes build and package selection issues.
+          - { os: ["macos", "macos-latest"], config: ["3.11",  "py311"] }
 
     runs-on: ${{ matrix.os[1] }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    name: ${{ matrix.config[1] }}
+    name: ${{ matrix.os[0] }}-${{ matrix.config[1] }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ lib64
 log/
 parts/
 pyvenv.cfg
+testing.log
 var/

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/zope-product
 [meta]
 template = "zope-product"
-commit-id = "efb3f62f0f2d8deea657bae8db49a191698e62ef"
+commit-id = "200573eb414d2228d463da3de7d71a6d6335a704"
 
 [python]
 with-pypy = false
@@ -10,6 +10,7 @@ with-legacy-python = true
 with-sphinx-doctests = false
 with-windows = false
 with-future-python = false
+with-macos = false
 
 [coverage]
 fail-under = 85

--- a/.meta.toml
+++ b/.meta.toml
@@ -10,7 +10,7 @@ with-legacy-python = true
 with-sphinx-doctests = false
 with-windows = false
 with-future-python = false
-with-macos = false
+with-macos = true
 
 [coverage]
 fail-under = 85

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 6.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Make ``test_getCatalogPlan_partial`` test more stable.
+  On Mac you would sometimes get a different query plan.
+  (`#140 <https://github.com/zopefoundation/Products.ZCatalog/issues/140>`_)
 
 
 6.3 (2022-08-03)

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
     ],

--- a/src/Products/ZCatalog/tests/test_plan.py
+++ b/src/Products/ZCatalog/tests/test_plan.py
@@ -238,13 +238,13 @@ class TestCatalogPlan(cleanup.CleanUp, unittest.TestCase):
 
         class SlowFieldIndex(FieldIndex):
             def query_index(self, record, resultset=None):
-                time.sleep(0.1)
+                time.sleep(0.05)
                 return super(SlowFieldIndex, self).query_index(
                     record, resultset)
 
         class SlowerDateRangeIndex(DateRangeIndex):
             def query_index(self, record, resultset=None):
-                time.sleep(0.2)
+                time.sleep(0.4)
                 return super(SlowerDateRangeIndex, self).query_index(
                     record, resultset)
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,18 +11,19 @@ envlist =
     py38
     py39
     py310
+    py311
     coverage
 
 [testenv]
 skip_install = true
 deps =
-    zc.buildout >= 3.0.0rc3
+    zc.buildout >= 3.0.1
     wheel > 0.37
 commands_pre =
     py27,py35: {envbindir}/buildout -nc {toxinidir}/buildout4.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
     !py27-!py35: {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
 commands =
-    {envbindir}/test {posargs:-cv}
+    {envdir}/bin/test {posargs:-cv}
 
 [testenv:lint]
 basepython = python3
@@ -65,7 +66,7 @@ deps =
     coverage-python-version
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
-    coverage run {envbindir}/test {posargs:-cv}
+    coverage run {envdir}/bin/test {posargs:-cv}
     coverage html
     coverage report -m --fail-under=85
 


### PR DESCRIPTION
On Mac you would sometimes get a different query plan.
Fixes https://github.com/zopefoundation/Products.ZCatalog/issues/140.
(Or at least I hope that this fixes the issue.)

The first commit updates to the latest meta config.