### PR TITLE
Fix DateTime SyntaxError while browsing DateIndex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Drop support for Python 2.7, 3.5, 3.6.
 
+- Fix SyntaxError on the Browse tab for DateIndex.
+  (`#144 <https://github.com/zopefoundation/Products.ZCatalog/issues/144>`_)
+
 
 6.4 (2022-12-13)
 ----------------

--- a/src/Products/PluginIndexes/dtml/browseIndex.dtml
+++ b/src/Products/PluginIndexes/dtml/browseIndex.dtml
@@ -31,10 +31,10 @@ The index "&dtml-getId;" contains <dtml-var items fmt=collection-length thousand
               DateIndexes store dates packed into an integer, unpack
               into year, month, day, hour and minute, no seconds and UTC.
             --></dtml-comment>
-            <dtml-var "DateTime(((_['sequence-key'] - 44640) / 535680),
-                                ((_['sequence-key'] - 1440) / 44640 ) % 12 or 12,
-                                (_['sequence-key'] / 1440 ) % 31 or 31,
-                                (_['sequence-key'] / 60 ) % 24,
+            <dtml-var "DateTime(((_['sequence-key'] - 44640) // 535680),
+                                ((_['sequence-key'] - 1440) // 44640 ) % 12 or 12,
+                                (_['sequence-key'] // 1440 ) % 31 or 31,
+                                (_['sequence-key'] // 60 ) % 24,
                                 (_['sequence-key'] ) % 60,
                                 0, 'UTC')">
           <dtml-else>


### PR DESCRIPTION
Fixes #144 

This operation is intended to be floor division (discarding the remainder to give an integer result). But the meaning of `/` changed from Python 2 to 3, so now we need to use `//`.