### PR TITLE
Fix TypeError on the Query Report tab

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-7.1 (unreleased)
-----------------
+7.0.1 (unreleased)
+------------------
 
-- Nothing changed yet.
+- Fix TypeError on the Query Report tab.
+  (`#136 <https://github.com/zopefoundation/Products.ZCatalog/issues/136>`_)
 
 
 7.0 (2023-03-14)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 setup(
     name='Products.ZCatalog',
-    version='7.1.dev0',
+    version='7.0.1.dev0',
     url='https://github.com/zopefoundation/Products.ZCatalog',
     project_urls={
         'Issue Tracker': 'https://github.com/zopefoundation/'

--- a/src/Products/ZCatalog/dtml/catalogReport.dtml
+++ b/src/Products/ZCatalog/dtml/catalogReport.dtml
@@ -36,7 +36,7 @@
                         </td>
                         <td>
                             <dtml-var expr="'%3.2f' % last['duration']">ms
-                            [<dtml-in expr="last['details']" sort mapping>
+                            [<dtml-in expr="last['details']" mapping>
                                 &dtml-id;: <dtml-var expr="'%3.2f' % duration">ms,
                             </dtml-in>]
                         </td>


### PR DESCRIPTION
Fixes #136 

A sequence of dicts doesn't have an inherent sort order.

That's fine: in this use case, we're displaying a list of which indexes were applied in the latest slow query for a given query key. It is more useful to show them in the order they were actually applied (which can reveal an inefficient query plan) rather than sorted alphabetically by index id.