### PR TITLE
Searches with "not" in a KeywordIndex do not return records that do not contain a value for the index (2nd)

### DIFF
--- a/src/Products/PluginIndexes/unindex.py
+++ b/src/Products/PluginIndexes/unindex.py
@@ -447,6 +447,16 @@ class UnIndex(SimpleItem):
 
         operator = record.operator
 
+        # If not is the first operator, we need to start with the full
+        # resultset from the catalog
+        if not_parm and resultset is None:
+            try:
+                resultset = IISet(self.aq_parent.uids.values())
+            except AttributeError:
+                # this is needed for tests, or where indexes are used outside
+                # of a catalog
+                pass
+
         cachekey = None
         cache = self.getRequestCache()
         if cache is not None:

--- a/src/Products/ZCatalog/tests/test_catalog.py
+++ b/src/Products/ZCatalog/tests/test_catalog.py
@@ -397,10 +397,10 @@ class TestCatalog(unittest.TestCase):
 
         class DummyKWNot(ExtensionClass.Base):
             field = 'foo'
+
             def __init__(self, keywords=None):
                 if keywords:
                     self.keywords = keywords
-
 
         catalog.catalogObject(DummyKWNot([10, 11, 12]), "1")
         catalog.catalogObject(DummyKWNot([11, 12]), "2")
@@ -409,11 +409,13 @@ class TestCatalog(unittest.TestCase):
         from Products.ZCatalog.plan import CatalogPlan
         from unittest.mock import patch
 
-        with patch.object(CatalogPlan, "plan", return_value=["field", "keywords"]):
+        with patch.object(
+                CatalogPlan, "plan", return_value=["field", "keywords"]):
             a = catalog({'keywords': {"not": [10]}, 'field': 'foo'})
             self.assertEqual(len(a), 2)
 
-        with patch.object(CatalogPlan, "plan", return_value=["keywords", "field"]):
+        with patch.object(
+                CatalogPlan, "plan", return_value=["keywords", "field"]):
             a = catalog({'keywords': {"not": [10]}, 'field': 'foo'})
             self.assertEqual(len(a), 2)
 

--- a/src/Products/ZCatalog/tests/test_catalog.py
+++ b/src/Products/ZCatalog/tests/test_catalog.py
@@ -388,6 +388,35 @@ class TestCatalog(unittest.TestCase):
         a = catalog(att3='none')
         self.assertEqual(len(a), 0)
 
+    def test_keyword_index_index_not_query_order(self):
+        # Queries with empty keys used to return all.
+        from Products.ZCatalog.Catalog import Catalog
+        catalog = Catalog()
+        catalog.addIndex('keywords', KeywordIndex('keywords'))
+        catalog.addIndex('field', FieldIndex('field'))
+
+        class DummyKWNot(ExtensionClass.Base):
+            field = 'foo'
+            def __init__(self, keywords=None):
+                if keywords:
+                    self.keywords = keywords
+
+
+        catalog.catalogObject(DummyKWNot([10, 11, 12]), "1")
+        catalog.catalogObject(DummyKWNot([11, 12]), "2")
+        catalog.catalogObject(DummyKWNot(), "3")
+
+        from Products.ZCatalog.plan import CatalogPlan
+        from unittest.mock import patch
+
+        with patch.object(CatalogPlan, "plan", return_value=["field", "keywords"]):
+            a = catalog({'keywords': {"not": [10]}, 'field': 'foo'})
+            self.assertEqual(len(a), 2)
+
+        with patch.object(CatalogPlan, "plan", return_value=["keywords", "field"]):
+            a = catalog({'keywords': {"not": [10]}, 'field': 'foo'})
+            self.assertEqual(len(a), 2)
+
 
 class TestCatalogSortBatch(unittest.TestCase):
 


### PR DESCRIPTION
This is another try to fix https://github.com/zopefoundation/Products.ZCatalog/issues/148

See also https://github.com/zopefoundation/Products.ZCatalog/pull/158