### PR TITLE
Fix logic for inverting a BooleanIndex when documents are unindexed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 7.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix performance of removing a document from a BooleanIndex.
+  (`#20 <https://github.com/zopefoundation/Products.ZCatalog/issues/20>`_)
 
 
 7.2 (2025-07-21)

--- a/src/Products/PluginIndexes/BooleanIndex/BooleanIndex.py
+++ b/src/Products/PluginIndexes/BooleanIndex/BooleanIndex.py
@@ -151,7 +151,7 @@ class BooleanIndex(UnIndex):
         elif check:
             # is the index (after removing the current entry) larger than
             # 60% of the total length? than switch the indexed value
-            if (self._index_length.value) <= ((self._length.value - 1) * 0.6):
+            if (self._index_length.value) >= ((self._length.value - 1) * 0.6):
                 self._invert_index(documentId)
                 return
 

--- a/src/Products/PluginIndexes/BooleanIndex/tests.py
+++ b/src/Products/PluginIndexes/BooleanIndex/tests.py
@@ -254,6 +254,28 @@ class TestBooleanIndex(unittest.TestCase):
         self.assertEqual(list(index._index), [2])
         self.assertEqual(list(res), [1, 3, 4])
 
+    def test_index_inversion_when_doc_removed(self):
+        index = self._makeOne()
+        # Add 4 false values and 6 true values
+        for i in range(0, 10):
+            obj = Dummy(i, False if i < 4 else True)
+            index._index_object(obj.id, obj, attr="truth")
+        # The index stores the docids that are False,
+        # since >= 60% of the documents are True
+        self.assertFalse(index._index_value)
+        # Now remove enough true values that >= 60% of
+        # the values are False, which should invert the index.
+        # Check at each step to make sure we aren't
+        # accidentally inverting it multiple times.
+        index.unindex_object(9)
+        self.assertFalse(index._index_value)
+        index.unindex_object(8)
+        self.assertFalse(index._index_value)
+        index.unindex_object(7)
+        self.assertFalse(index._index_value)
+        index.unindex_object(6)
+        self.assertTrue(index._index_value)
+
     def test_getCounter(self):
         index = self._makeOne()
 

--- a/src/Products/PluginIndexes/BooleanIndex/tests.py
+++ b/src/Products/PluginIndexes/BooleanIndex/tests.py
@@ -254,8 +254,9 @@ class TestBooleanIndex(unittest.TestCase):
         self.assertEqual(list(index._index), [2])
         self.assertEqual(list(res), [1, 3, 4])
 
-    def test_index_inversion_when_doc_removed(self):
+    def test_index_inversion_hysteresis(self):
         index = self._makeOne()
+
         # Add 4 false values and 6 true values
         for i in range(0, 10):
             obj = Dummy(i, False if i < 4 else True)
@@ -263,6 +264,7 @@ class TestBooleanIndex(unittest.TestCase):
         # The index stores the docids that are False,
         # since >= 60% of the documents are True
         self.assertFalse(index._index_value)
+
         # Now remove enough true values that >= 60% of
         # the values are False, which should invert the index.
         # Check at each step to make sure we aren't
@@ -275,6 +277,16 @@ class TestBooleanIndex(unittest.TestCase):
         self.assertFalse(index._index_value)
         index.unindex_object(6)
         self.assertTrue(index._index_value)
+
+        # Now add more true values and check that we invert back again.
+        index._index_object(10, Dummy(10, True), attr="truth")
+        self.assertTrue(index._index_value)
+        index._index_object(11, Dummy(11, True), attr="truth")
+        self.assertTrue(index._index_value)
+        index._index_object(12, Dummy(12, True), attr="truth")
+        self.assertTrue(index._index_value)
+        index._index_object(13, Dummy(13, True), attr="truth")
+        self.assertFalse(index._index_value)
 
     def test_getCounter(self):
         index = self._makeOne()


### PR DESCRIPTION
- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #20
