### PR TITLE
Remove specialized tox test configuration for GitHub

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,8 +43,8 @@ jobs:
       with:
         persist-credentials: false
     - name: Install uv + caching
-      # astral/setup-uv@7.1.4
-      uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244
+      # astral/setup-uv@7.2.0
+      uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b
       with:
         enable-cache: true
         cache-dependency-glob: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,10 +53,6 @@ jobs:
         python-version: ${{ matrix.config[0] }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
-      if: ${{ !startsWith(runner.os, 'Mac') }}
-      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}
-    - name: Test (macOS)
-      if: ${{ startsWith(runner.os, 'Mac') }}
       run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}
     - name: Coverage
       if: matrix.config[1] == 'coverage'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
       run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}
     - name: Test (macOS)
       if: ${{ startsWith(runner.os, 'Mac') }}
-      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}-universal2
+      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/zope-product
 [meta]
 template = "zope-product"
-commit-id = "446e9797"
+commit-id = "8bf5a8e1"
 
 [python]
 with-pypy = false
@@ -26,20 +26,3 @@ additional-rules = [
 
 [tox]
 use-flake8 = true
-testenv-deps = [
-    "cffi >= 1.17.0rc1",
-    "# The universal2 environment is for Python on macOS built with",
-    "# universal2 mode instead of architecture-specific. These dependencies",
-    "# must be installed separately, zc.buildout is incompatible with the",
-    "# universal2 mode and cannot install them itself.",
-    "universal2: zope.interface",
-    "universal2: zope.security",
-    "universal2: zope.container",
-    "universal2: Persistence",
-    "universal2: Acquisition",
-    "universal2: AccessControl",
-    "universal2: zodbpickle",
-    "universal2: charset_normalizer",
-    "universal2: MarkupSafe",
-    "universal2: zope.testrunner",
-    ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: autopep8
       args: [--in-place, --aggressive, --aggressive]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     - id: pyupgrade
       args: [--py310-plus]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-
 [project]
 name = "Products.ZCatalog"
 version = "7.4.dev0"

--- a/tox.ini
+++ b/tox.ini
@@ -18,21 +18,6 @@ deps =
     setuptools >= 78.1.1,< 81
     zc.buildout
     wheel
-    cffi >= 1.17.0rc1
-    # The universal2 environment is for Python on macOS built with
-    # universal2 mode instead of architecture-specific. These dependencies
-    # must be installed separately, zc.buildout is incompatible with the
-    # universal2 mode and cannot install them itself.
-    universal2: zope.interface
-    universal2: zope.security
-    universal2: zope.container
-    universal2: Persistence
-    universal2: Acquisition
-    universal2: AccessControl
-    universal2: zodbpickle
-    universal2: charset_normalizer
-    universal2: MarkupSafe
-    universal2: zope.testrunner
 setenv =
 commands_pre =
     {envbindir}/buildout -nc {toxinidir}/buildout.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
@@ -45,21 +30,6 @@ deps =
     git+https://github.com/pypa/setuptools.git\#egg=setuptools
     zc.buildout
     wheel
-    cffi >= 1.17.0rc1
-    # The universal2 environment is for Python on macOS built with
-    # universal2 mode instead of architecture-specific. These dependencies
-    # must be installed separately, zc.buildout is incompatible with the
-    # universal2 mode and cannot install them itself.
-    universal2: zope.interface
-    universal2: zope.security
-    universal2: zope.container
-    universal2: Persistence
-    universal2: Acquisition
-    universal2: AccessControl
-    universal2: zodbpickle
-    universal2: charset_normalizer
-    universal2: MarkupSafe
-    universal2: zope.testrunner
 
 
 [testenv:release-check]


### PR DESCRIPTION
It is no longer needed and can cause problems, see explanation in https://github.com/zopefoundation/Zope/pull/1282